### PR TITLE
This adds support for using a custom CA cert (or path) using existing Vault env vars

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -158,6 +158,16 @@ module Vault
           connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
         end
 
+        # Use custom CA cert for verification
+        if ssl_ca_cert
+          connection.ca_file = ssl_ca_cert
+        end
+
+        # Use custom CA path that contains CA certs
+        if ssl_ca_path
+          connection.ca_path = ssl_ca_path
+        end
+
         # Naughty, naughty, naughty! Don't blame when when someone hops in
         # and executes a MITM attack!
         unless ssl_verify

--- a/lib/vault/configurable.rb
+++ b/lib/vault/configurable.rb
@@ -11,6 +11,8 @@ module Vault
         :proxy_port,
         :proxy_username,
         :ssl_pem_file,
+        :ssl_ca_cert,
+        :ssl_ca_path,
         :ssl_verify,
       ]
     end

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -53,6 +53,19 @@ module Vault
         ENV["VAULT_SSL_CERT"]
       end
 
+      # The path to the CA cert on disk to use for certificate verification
+      # @return [String, nil]
+      def ssl_ca_cert
+        ENV["VAULT_CACERT"]
+      end
+      #
+      # The path to the directory on disk holding CA certs to use
+      # for certificate verification
+      # @return [String, nil]
+      def ssl_ca_path
+        ENV["VAULT_CAPATH"]
+      end
+
       # Verify SSL requests (default: true)
       #
       # @return [true, false]


### PR DESCRIPTION
Vault supports using custom CA certs that can be set for the client
to read
https://github.com/hashicorp/vault/blob/a07bd713ca54f3e33758872b8bc8578627445cdd/command/meta.go#L26-L27

This commit allows the user to use the same ENV vars as they would
using the official vault client in the ruby client.

Thanks for the awesome work on this gem - it's super awesome, can't wait to play with it more.