### PR TITLE
Add a basic integration test for API client read_timeout

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -208,7 +208,7 @@ module Vault
           error(response)
         end
       end
-    rescue SocketError, Errno::ECONNREFUSED, EOFError
+    rescue SocketError, Errno::ECONNREFUSED, EOFError, Net::ReadTimeout, Net::OpenTimeout
       raise HTTPConnectionError.new(address)
     end
 

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -1,0 +1,39 @@
+require "spec_helper"
+
+module Vault
+  describe Client do
+
+    def free_address
+      server = TCPServer.new("localhost", 0)
+      address = ["localhost", server.addr[1]]
+      server.close
+      address
+    end
+
+    describe "#request" do
+      specify "raises HTTPConnectionError if it takes too long to read packets from the connection" do
+        TCPServer.open('localhost', 0) do |server|
+          Thread.new do
+            client = server.accept
+            sleep 3
+            client.close
+          end
+
+          address = "http://%s:%s" % ["localhost", server.addr[1]]
+
+          client = described_class.new(address: address, token: "foo", read_timeout: 0.01)
+
+          expect { client.request(:get, "/", {}, {}) }.to raise_error(HTTPConnectionError)
+        end
+      end
+
+      specify "raises HTTPConnectionError if the port on the remote server is not open" do
+        address = "http://%s:%s" % free_address
+
+        client = described_class.new(address: address, token: "foo")
+
+        expect { client.request(:get, "/", {}, {}) }.to raise_error(HTTPConnectionError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I would add an integration test for ssl timeouts, but they don't seem to work in ruby, my guess is that it's related to problems with `Timeout`.

Hopefully this will do for the meantime, as it tests the timeout that is likely to affect most people (e.g. if a backend vault is using takes too long to respond).