### PR TITLE
Vault requires TLSv1.2 - make sure we use it

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -147,6 +147,9 @@ module Vault
         # Turn on SSL
         connection.use_ssl = true
 
+        # Vault requires TLS1.2
+        connection.ssl_version = :TLSv1_2
+
         # Turn on secure cookies
         cookie.secure = true
 


### PR DESCRIPTION
Vault is opinionated about using TLSv1.2 - https://github.com/hashicorp/vault/issues/427

The Ruby client may not use it by default, depending on the underlying OpenSSL libraries.
This will typically affect RHEL and similar.

Here's a patch to force the TLS version.