### PR TITLE
Make the client threadsafe

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -56,12 +56,7 @@ module Vault
     def initialize(options = {})
       # Use any options given, but fall back to the defaults set on the module
       Vault::Configurable.keys.each do |key|
-        value = if options[key].nil?
-          Vault.instance_variable_get(:"@#{key}")
-        else
-          options[key]
-        end
-
+        value = options.key?(key) ? options[key] : Defaults.public_send(key)
         instance_variable_set(:"@#{key}", value)
       end
     end

--- a/lib/vault/configurable.rb
+++ b/lib/vault/configurable.rb
@@ -30,17 +30,6 @@ module Vault
       yield self
     end
 
-    # Reset all the values to their defaults.
-    #
-    # @return [self]
-    def reset!
-      defaults = Defaults.options
-      Vault::Configurable.keys.each do |key|
-        instance_variable_set(:"@#{key}", defaults[key])
-      end
-      self
-    end
-
     # The list of options for this configurable.
     #
     # @return [Hash<Symbol, Object>]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,8 @@ RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
 
   # Ensure our configuration is reset on each run.
-  config.before(:each) { Vault.reset! }
-  config.after(:each)  { Vault.reset! }
+  config.before(:each) { Vault.setup! }
+  config.after(:each)  { Vault.setup! }
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing

--- a/spec/support/vault_server.rb
+++ b/spec/support/vault_server.rb
@@ -49,11 +49,6 @@ module RSpec
         end
 
         if output.match(/Unseal Key: (.+)/)
-          STDOUT.puts
-          STDOUT.puts
-          STDOUT.puts $1.strip
-          STDOUT.puts
-          STDOUT.puts
           @unseal_token = $1.strip
         else
           raise "Vault did not return an unseal token!"

--- a/spec/unit/vault_spec.rb
+++ b/spec/unit/vault_spec.rb
@@ -4,42 +4,24 @@ describe Vault do
   it "sets the default values" do
     Vault::Configurable.keys.each do |key|
       value = Vault::Defaults.send(key)
-      expect(Vault.instance_variable_get(:"@#{key}")).to eq(value)
+      expect(Vault.client.instance_variable_get(:"@#{key}")).to eq(value)
     end
   end
 
   describe ".client" do
-    it "creates an Vault::Client" do
+    it "returns the Vault::Client" do
       expect(Vault.client).to be_a(Vault::Client)
-    end
-
-    it "caches the client when the same options are passed" do
-      expect(Vault.client).to eq(Vault.client)
-    end
-
-    it "returns a fresh client when options are not the same" do
-      original_client = Vault.client
-
-      # Change settings
-      Vault.address = "http://new.address"
-      new_client = Vault.client
-
-      # Get it one more tmie
-      current_client = Vault.client
-
-      expect(original_client).to_not eq(new_client)
-      expect(new_client).to eq(current_client)
     end
   end
 
   describe ".configure" do
     Vault::Configurable.keys.each do |key|
-      it "sets the #{key.to_s.gsub("_", " ")}" do
+      it "sets the client's #{key.to_s.gsub("_", " ")}" do
         Vault.configure do |config|
           config.send("#{key}=", key)
         end
 
-        expect(Vault.instance_variable_get(:"@#{key}")).to eq(key)
+        expect(Vault.client.instance_variable_get(:"@#{key}")).to eq(key)
       end
     end
   end


### PR DESCRIPTION
The previous implementation was not threadsafe and resulted in some
serious sadness, especially when used in a multi-threaded env. This
commit changes the library to be threadsafe while keeping the
original API intact.