### PR TITLE
Allow user of library to change the ssl ciphers used by Client

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -171,7 +171,7 @@ module Vault
         connection.ssl_version = "TLSv1_2"
 
         # Only use secure ciphers
-        connection.ciphers = "TLSv1.2:!aNULL:!eNULL"
+        connection.ciphers = ssl_ciphers
 
         # Turn on secure cookies
         cookie.secure = true

--- a/lib/vault/configurable.rb
+++ b/lib/vault/configurable.rb
@@ -12,6 +12,7 @@ module Vault
         :proxy_port,
         :proxy_username,
         :read_timeout,
+        :ssl_ciphers,
         :ssl_pem_file,
         :ssl_ca_cert,
         :ssl_ca_path,

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -10,6 +10,8 @@ module Vault
     # @return [String]
     VAULT_DISK_TOKEN = Pathname.new("~/.vault-token").expand_path.freeze
 
+    SSL_CIPHERS = "TLSv1.2:!aNULL:!eNULL".freeze
+
     class << self
       # The list of calculated options for this configurable.
       # @return [Hash]
@@ -68,6 +70,14 @@ module Vault
       # @return [String, nil]
       def read_timeout
         ENV["VAULT_READ_TIMEOUT"]
+      end
+
+      # The ciphers that will be used when communicating with vault over ssl
+      # You should only change the defaults if the ciphers aren't available on 
+      # your platform and you know what you are doing
+      # @return [String]
+      def ssl_ciphers
+        SSL_CIPHERS
       end
 
       # The path to a pem on disk to use with custom SSL verification


### PR DESCRIPTION
At time of writing the latest openssl available on ubuntu 12.04 (1.0.1-4ubuntu5.31) does not support TLS1.2 ciphers (though it does support the TLS1.2 **protocol**).

People running Ubuntu 12.04 can use the secure ciphers [recommended by Mozilla](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility).

```console
$ sudo dpkg -s openssl
Package: openssl
Status: install ok installed
Priority: optional
Section: utils
Installed-Size: 902
Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Architecture: amd64
Version: 1.0.1-4ubuntu5.31
Depends: libc6 (>= 2.15), libssl1.0.0 (>= 1.0.1)
....
```
```console
$ openssl ciphers
ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:SRP-DSS-AES-256-CBC-SHA:SRP-RSA-AES-256-CBC-SHA:SRP-AES-256-CBC-SHA:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA256:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-CAMELLIA256-SHA:DHE-DSS-CAMELLIA256-SHA:ECDH-RSA-AES256-GCM-SHA384:ECDH-ECDSA-AES256-GCM-SHA384:ECDH-RSA-AES256-SHA384:ECDH-ECDSA-AES256-SHA384:ECDH-RSA-AES256-SHA:ECDH-ECDSA-AES256-SHA:AES256-GCM-SHA384:AES256-SHA256:AES256-SHA:CAMELLIA256-SHA:PSK-AES256-CBC-SHA:ECDHE-RSA-DES-CBC3-SHA:ECDHE-ECDSA-DES-CBC3-SHA:SRP-DSS-3DES-EDE-CBC-SHA:SRP-RSA-3DES-EDE-CBC-SHA:SRP-3DES-EDE-CBC-SHA:EDH-RSA-DES-CBC3-SHA:EDH-DSS-DES-CBC3-SHA:ECDH-RSA-DES-CBC3-SHA:ECDH-ECDSA-DES-CBC3-SHA:DES-CBC3-SHA:PSK-3DES-EDE-CBC-SHA:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:SRP-DSS-AES-128-CBC-SHA:SRP-RSA-AES-128-CBC-SHA:SRP-AES-128-CBC-SHA:DHE-DSS-AES128-GCM-SHA256:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES128-SHA256:DHE-DSS-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:DHE-RSA-SEED-SHA:DHE-DSS-SEED-SHA:DHE-RSA-CAMELLIA128-SHA:DHE-DSS-CAMELLIA128-SHA:ECDH-RSA-AES128-GCM-SHA256:ECDH-ECDSA-AES128-GCM-SHA256:ECDH-RSA-AES128-SHA256:ECDH-ECDSA-AES128-SHA256:ECDH-RSA-AES128-SHA:ECDH-ECDSA-AES128-SHA:AES128-GCM-SHA256:AES128-SHA256:AES128-SHA:SEED-SHA:CAMELLIA128-SHA:PSK-AES128-CBC-SHA:ECDHE-RSA-RC4-SHA:ECDHE-ECDSA-RC4-SHA:ECDH-RSA-RC4-SHA:ECDH-ECDSA-RC4-SHA:RC4-SHA:RC4-MD5:PSK-RC4-SHA:EDH-RSA-DES-CBC-SHA:EDH-DSS-DES-CBC-SHA:DES-CBC-SHA
```