### PR TITLE
Do not try to read a secret from logical

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    coderay (1.1.0)
     diff-lcs (1.2.5)
+    method_source (0.8.2)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rake (10.4.2)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
@@ -21,15 +27,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    slop (3.6.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 1.9)
+  pry
   rake (~> 10.0)
   rspec (~> 3.2)
   vault!
 
 BUNDLED WITH
-   1.10.3
+   1.10.6

--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -45,7 +45,11 @@ module Vault
     # @return [Secret]
     def write(path, data = {})
       json = client.put("/v1/#{path}", JSON.fast_generate(data))
-      return json.nil? ? read(path) : Secret.decode(json)
+      if json.nil?
+        return true
+      else
+        return Secret.decode(json)
+      end
     end
 
     # Delete the secret at the given path. If the secret does not exist, vault

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -19,14 +19,16 @@ module Vault
 
     describe "#write" do
       it "creates and returns the secret" do
-        result = subject.write("secret/test-write", zip: "zap")
+        subject.write("secret/test-write", zip: "zap")
+        result = subject.read("secret/test-write")
         expect(result).to be
         expect(result.data).to eq(zip: "zap")
       end
 
       it "overwrites existing secrets" do
         subject.write("secret/test-overwrite", zip: "zap")
-        result = subject.write("secret/test-overwrite", bacon: true)
+        subject.write("secret/test-overwrite", bacon: true)
+        result = subject.read("secret/test-overwrite")
         expect(result).to be
         expect(result.data).to eq(bacon: true)
       end

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.9"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "rake",    "~> 10.0"
   spec.add_development_dependency "rspec",   "~> 3.2"
 end


### PR DESCRIPTION
Previously the client would automatically attempt to read a secret if no JSON
was returned. This causes problems for paths that are "write-only", like
config endpoints.

Much like the Vault client, the endpoint will just return "success" if the
write succeeds.

Fixes GH-11