### PR TITLE
Update configuration class

### DIFF
--- a/lib/vault/configurable.rb
+++ b/lib/vault/configurable.rb
@@ -14,6 +14,7 @@ module Vault
         :read_timeout,
         :ssl_ciphers,
         :ssl_pem_file,
+        :ssl_pem_passphrase,
         :ssl_ca_cert,
         :ssl_ca_path,
         :ssl_verify,


### PR DESCRIPTION
Looks like the configuration element for the pem passphrase was missing. Added.