### PR TITLE
Fixed `.configure` example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Usage
 The following configuration options are available:
 
 ```ruby
-Vault::Client.configure do |config|
+Vault.configure do |config|
   # The address of the Vault server, also read as ENV["VAULT_ADDR"]
   config.address = "https://127.0.0.1:8200"
 


### PR DESCRIPTION
Doing `Vault::Client.configure` complains `NoMethodError: undefined method `configure' for Vault::Client:Class`. Based on other parts of the doc and the code, it looks like you'd use `Vault::Client.new.configure` when configuring a new instance of the client. But to configure the Vault singleton, you'd use `Vault.configure`.
