### PR TITLE
Add CGI.escape(path) to logical methods

### DIFF
--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -1,5 +1,5 @@
-require "cgi"
-
+#require "cgi"
+#
 require_relative "secret"
 require_relative "../client"
 require_relative "../request"
@@ -26,7 +26,7 @@ module Vault
     #
     # @return [Secret, nil]
     def read(path)
-      path = CGI.escape(path)
+      #path = CGI.escape(path)
       json = client.get("/v1/#{path}")
       return Secret.decode(json)
     rescue HTTPError => e
@@ -47,7 +47,7 @@ module Vault
     #
     # @return [Secret]
     def write(path, data = {})
-      path = CGI.escape(path)
+      #path = CGI.escape(path)
       json = client.put("/v1/#{path}", JSON.fast_generate(data))
       if json.nil?
         return true
@@ -67,7 +67,7 @@ module Vault
     #
     # @return [true]
     def delete(path)
-      path = CGI.escape(path)
+      #path = CGI.escape(path)
       client.delete("/v1/#{path}")
       return true
     end

--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -1,5 +1,5 @@
-#require "cgi"
-#
+require "cgi"
+
 require_relative "secret"
 require_relative "../client"
 require_relative "../request"
@@ -26,7 +26,7 @@ module Vault
     #
     # @return [Secret, nil]
     def read(path)
-      #path = CGI.escape(path)
+      path = CGI.escape(path)
       json = client.get("/v1/#{path}")
       return Secret.decode(json)
     rescue HTTPError => e
@@ -47,7 +47,7 @@ module Vault
     #
     # @return [Secret]
     def write(path, data = {})
-      #path = CGI.escape(path)
+      path = CGI.escape(path)
       json = client.put("/v1/#{path}", JSON.fast_generate(data))
       if json.nil?
         return true
@@ -67,7 +67,7 @@ module Vault
     #
     # @return [true]
     def delete(path)
-      #path = CGI.escape(path)
+      path = CGI.escape(path)
       client.delete("/v1/#{path}")
       return true
     end

--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -1,3 +1,5 @@
+require "CGI"
+
 require_relative "secret"
 require_relative "../client"
 require_relative "../request"
@@ -24,6 +26,7 @@ module Vault
     #
     # @return [Secret, nil]
     def read(path)
+      path = CGI.escape(path)
       json = client.get("/v1/#{path}")
       return Secret.decode(json)
     rescue HTTPError => e
@@ -44,6 +47,7 @@ module Vault
     #
     # @return [Secret]
     def write(path, data = {})
+      path = CGI.escape(path)
       json = client.put("/v1/#{path}", JSON.fast_generate(data))
       if json.nil?
         return true
@@ -63,6 +67,7 @@ module Vault
     #
     # @return [true]
     def delete(path)
+      path = CGI.escape(path)
       client.delete("/v1/#{path}")
       return true
     end

--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -1,4 +1,4 @@
-require "CGI"
+require "cgi"
 
 require_relative "secret"
 require_relative "../client"

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -17,7 +17,9 @@ module Vault
       end
 
       it "is able to read a secret with % in the path" do
-        expect(subject.read("secret/test-read@%")).to_not raise_error
+        expect {
+          subject.read("secret/test-read@%")
+        }.to_not raise_error
       end
     end
 
@@ -38,7 +40,9 @@ module Vault
       end
 
       it "is able to write a secret with % in the path" do
-        expect(subject.write("secret/test-write@%", zip: "zap")).to_not raise_error
+        expect {
+          subject.write("secret/test-write@%", zip: "zap")
+        }.to_not raise_error
       end
     end
 
@@ -58,7 +62,9 @@ module Vault
       end
 
       it "can delete a secret with % in the path" do
-        expect(subject.delete("secret/delete@%")).to be(true)
+        expect {
+          subject.delete("secret/delete@%")
+        }.to_not raise_error
       end
     end
   end

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -17,10 +17,7 @@ module Vault
       end
 
       it "is able to read a secret with % in the path" do
-        subject.write("secret/test-read@%", foo: "bar")
-        secret = subject.read("secret/test-read@%")
-        expect(secret).to be
-        expect(secret.data).to eq(foo: "bar")
+        expect(subject.read("secret/test-read@%")).to_not raise_error
       end
     end
 
@@ -41,10 +38,7 @@ module Vault
       end
 
       it "is able to write a secret with % in the path" do
-        subject.write("secret/test-write@%", zip: "zap")
-        result = subject.read("secret/test-write@%")
-        expect(result).to be
-        expect(result.data).to eq(zip: "zap")
+        expect(subject.write("secret/test-write@%", zip: "zap")).to_not raise_error
       end
     end
 
@@ -64,9 +58,7 @@ module Vault
       end
 
       it "can delete a secret with % in the path" do
-        subject.write("secret/delete@%", foo: "bar")
         expect(subject.delete("secret/delete@%")).to be(true)
-        expect(subject.read("secret/delete@%")).to be(nil)
       end
     end
   end

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -20,6 +20,10 @@ module Vault
         expect {
           subject.read("secret/test-read@%")
         }.to_not raise_error
+        subject.write("secret/test-read@%", foo: "bar")
+        secret = subject.read("secret/test-read@%")
+        expect(secret).to be
+        expect(secret.data).to eq(foo: "bar")
       end
     end
 
@@ -43,6 +47,10 @@ module Vault
         expect {
           subject.write("secret/test-write@%", zip: "zap")
         }.to_not raise_error
+        subject.write("secret/test-write@%", zip: "zap")
+        result = subject.read("secret/test-write@%")
+        expect(result).to be
+        expect(result.data).to eq(zip: "zap")
       end
     end
 
@@ -65,6 +73,9 @@ module Vault
         expect {
           subject.delete("secret/delete@%")
         }.to_not raise_error
+        subject.write("secret/delete@%", foo: "bar")
+        expect(subject.delete("secret/delete@%")).to be(true)
+        expect(subject.read("secret/delete@%")).to be(nil)
       end
     end
   end

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -15,16 +15,6 @@ module Vault
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
-
-      it "is able to read a secret with % in the path" do
-        expect {
-          subject.read("secret/test-read@%")
-        }.to_not raise_error
-        subject.write("secret/test-read@%", foo: "bar")
-        secret = subject.read("secret/test-read@%")
-        expect(secret).to be
-        expect(secret.data).to eq(foo: "bar")
-      end
     end
 
     describe "#write" do
@@ -42,16 +32,6 @@ module Vault
         expect(result).to be
         expect(result.data).to eq(bacon: true)
       end
-
-      it "is able to write a secret with % in the path" do
-        expect {
-          subject.write("secret/test-write@%", zip: "zap")
-        }.to_not raise_error
-        subject.write("secret/test-write@%", zip: "zap")
-        result = subject.read("secret/test-write@%")
-        expect(result).to be
-        expect(result.data).to eq(zip: "zap")
-      end
     end
 
     describe "#delete" do
@@ -68,15 +48,15 @@ module Vault
           subject.delete("secret/delete")
         }.to_not raise_error
       end
+    end
 
-      it "can delete a secret with % in the path" do
-        expect {
-          subject.delete("secret/delete@%")
-        }.to_not raise_error
-        subject.write("secret/delete@%", foo: "bar")
-        expect(subject.delete("secret/delete@%")).to be(true)
-        expect(subject.read("secret/delete@%")).to be(nil)
-      end
+    it "can write, read, delete with % in path" do
+      subject.write("secret/foobar@%", foo: "bar")
+      secret = subject.read("secret/foobar@%")
+      expect(secret).to be
+      expect(secret.data).to eq(foo: "bar")
+      expect(subject.delete("secret/foobar@%")).to be(true)
+      expect(subject.read("secret/foobar@%")).to be(nil)
     end
   end
 end

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -15,6 +15,13 @@ module Vault
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
+
+      it "is able to read a secret with % in the path" do
+        subject.write("secret/test-read@%", foo: "bar")
+        secret = subject.read("secret/test-read@%")
+        expect(secret).to be
+        expect(secret.data).to eq(foo: "bar")
+      end
     end
 
     describe "#write" do
@@ -32,6 +39,13 @@ module Vault
         expect(result).to be
         expect(result.data).to eq(bacon: true)
       end
+
+      it "is able to write a secret with % in the path" do
+        subject.write("secret/test-write@%", zip: "zap")
+        result = subject.read("secret/test-write@%")
+        expect(result).to be
+        expect(result.data).to eq(zip: "zap")
+      end
     end
 
     describe "#delete" do
@@ -47,6 +61,12 @@ module Vault
           subject.delete("secret/delete")
           subject.delete("secret/delete")
         }.to_not raise_error
+      end
+
+      it "can delete a secret with % in the path" do
+        subject.write("secret/delete@%", foo: "bar")
+        expect(subject.delete("secret/delete@%")).to be(true)
+        expect(subject.read("secret/delete@%")).to be(nil)
       end
     end
   end


### PR DESCRIPTION
In case the path contains characters like '%' they should be URI-escaped. This will ensure the same behavior as the command line.

Example:

     vault read 'secret/user@%'

results in this HTTP request:

    GET /v1/secret/user@%25 HTTP/1.1
    Host: 127.0.0.1:8200
    User-Agent: Go-http-client/1.1
    X-Vault-Token: XXXXXX
    Accept-Encoding: gzip

While using the same path with ruby-vault, resulted in the following error:

    bad URI(is not URI?): /v1/secret/user@%

which comes from `/usr/lib/ruby/2.0.0/uri/common.rb:176` 

I considered putting this fix in `lib/vault/client.rb` in the `request` or `build_uri` methods. However, these methods support absolute URIs, which of course should not have the path escaped.