### PR TITLE
enable configurable retries on all idempotent actions without with_retry block

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -75,7 +75,7 @@ module Vault
     # Perform a GET request.
     # @see Client#request
     def get(path, params = {}, headers = {})
-      request(:get, path, params, headers)
+      request_with_retries(:get, path, params, headers)
     end
 
     # Perform a POST request.
@@ -87,7 +87,7 @@ module Vault
     # Perform a PUT request.
     # @see Client#request
     def put(path, data, headers = {})
-      request(:put, path, data, headers)
+      request_with_retries(:put, path, data, headers)
     end
 
     # Perform a PATCH request.
@@ -99,7 +99,19 @@ module Vault
     # Perform a DELETE request.
     # @see Client#request
     def delete(path, params = {}, headers = {})
-      request(:delete, path, params, headers)
+      request_with_retries(:delete, path, params, headers)
+    end
+
+    # Perform a request with retries for idempotent operations
+    # @see Client#request
+    def request_with_retries(verb, path, data = {}, headers = {})
+      unless options[:retry_options].nil?
+        send(:with_retries, options[:retry_options]) do
+          request(verb, path, data, headers)
+        end
+      else
+        request(verb, path, data, headers)
+      end
     end
 
     # Make an HTTP request with the given verb, data, params, and headers. If

--- a/lib/vault/configurable.rb
+++ b/lib/vault/configurable.rb
@@ -20,6 +20,7 @@ module Vault
         :ssl_verify,
         :ssl_timeout,
         :timeout,
+        :retry_options
       ]
     end
 

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -141,6 +141,12 @@ module Vault
       def timeout
         ENV["VAULT_TIMEOUT"]
       end
+
+      # A default options for retrying requests
+      # @return [Array, nil]
+      def retry_options
+        nil
+      end
     end
   end
 end

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -28,8 +28,8 @@ module Vault
     end
 
     describe "#get" do
-      it "delegates to the #request method" do
-        expect(subject).to receive(:request).with(:get, "/foo", {}, {})
+      it "delegates to the #request_with_retries method" do
+        expect(subject).to receive(:request_with_retries).with(:get, "/foo", {}, {})
         subject.get("/foo")
       end
     end
@@ -46,8 +46,8 @@ module Vault
     describe "#put" do
       let(:data) { double }
 
-      it "delegates to the #request method" do
-        expect(subject).to receive(:request).with(:put, "/foo", data, {})
+      it "delegates to the #request_with_retries method" do
+        expect(subject).to receive(:request_with_retries).with(:put, "/foo", data, {})
         subject.put("/foo", data)
       end
     end
@@ -62,8 +62,8 @@ module Vault
     end
 
     describe "#delete" do
-      it "delegates to the #request method" do
-        expect(subject).to receive(:request).with(:delete, "/foo", {}, {})
+      it "delegates to the #request_with_retries method" do
+        expect(subject).to receive(:request_with_retries).with(:delete, "/foo", {}, {})
         subject.delete("/foo")
       end
     end
@@ -72,6 +72,22 @@ module Vault
       it "converts spaces to + characters" do
         params = { emoji: "sad panda" }
         expect(subject.to_query_string(params)).to eq("emoji=sad+panda")
+      end
+    end
+
+    context "#request_with_retries" do
+      let(:retry_options) { { :retry_options => [Vault::HTTPServerError, :attempts => 1, :base => 0.00] } }
+
+      it "delegates to #request method when :retry_options is nil" do
+        expect(subject).to receive(:request).with(:get, "/foo", {}, {})
+        subject.request_with_retries(:get, "/foo")
+      end
+
+      it "delegates to #request method composed in #with_retry block when :retry_options is not nil" do
+        allow(subject).to receive(:options).and_return(subject.options.merge(retry_options))
+        expect(subject).to receive(:request).with(:get, "/foo", {}, {})
+        expect(subject).to receive(:with_retries).with(retry_options[:retry_options]).and_call_original
+        subject.request_with_retries(:get, "/foo")
       end
     end
 


### PR DESCRIPTION
I am hoping this can provide a convenient way of:

- configuring retry options that apply to all my operations
- enable retries without with_retry blocks
