### PR TITLE
Ignore data on a get redirect

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -217,7 +217,9 @@ module Vault
 
           case response
           when Net::HTTPRedirection
-            request(verb, response[LOCATION_HEADER], data, headers)
+            # on a redirect of a get, the url already contains the data as query string params
+            redirect_data = verb == :get ? {} : data
+            request(verb, response[LOCATION_HEADER], redirect_data, headers)
           when Net::HTTPSuccess
             success(response)
           else


### PR DESCRIPTION
When running a vault cluster (e.g. with consul backend) a possible request `https://my-vault.com/secret/key?list=true` to a vault slave results in a redirect. Furthermore that results in a new request of the vault client, which in turn results in a faulty request url (`https://my-vault.com/secret/key?list=true?list=true`) and the vault returns a `400` error.