### PR TITLE
Give ENV['VAULT_TOKEN'] precedence over VAULT_DISK_TOKEN

### DIFF
--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -42,11 +42,15 @@ module Vault
       # The vault token to use for authentiation.
       # @return [String, nil]
       def token
-        if VAULT_DISK_TOKEN.exist? && VAULT_DISK_TOKEN.readable?
-          VAULT_DISK_TOKEN.read
-        else
-          ENV["VAULT_TOKEN"]
+        unless ENV["VAULT_TOKEN"].nil?
+          return ENV["VAULT_TOKEN"]
         end
+
+        if VAULT_DISK_TOKEN.exist? && VAULT_DISK_TOKEN.readable?
+          return VAULT_DISK_TOKEN.read
+        end
+
+        nil
       end
 
       # The number of seconds to wait when trying to open a connection before

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -49,10 +49,10 @@ module Vault
         end
       end
 
-      it "prefers the local token over the environment" do
+      it "prefers the environment over local token" do
         File.open(token, "w") { |f| f.write("testing1") }
         with_stubbed_env("VAULT_TOKEN" => "testing2") do
-          expect(Defaults.token).to eq("testing1")
+          expect(Defaults.token).to eq("testing2")
         end
       end
     end


### PR DESCRIPTION
see issue https://github.com/hashicorp/vault-ruby/issues/59