### PR TITLE
Implement auth_tls api

### DIFF
--- a/lib/vault/api.rb
+++ b/lib/vault/api.rb
@@ -1,6 +1,7 @@
 module Vault
   module API
     require_relative "api/auth_token"
+    require_relative "api/auth_tls"
     require_relative "api/auth"
     require_relative "api/help"
     require_relative "api/logical"

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -142,5 +142,30 @@ module Vault
       client.token = old_token
       raise
     end
+
+    # Authenticate via a TLS authentication method. If authentication is
+    # successful, the resulting token will be stored on the client and used
+    # for future requests.
+    #
+    # @example
+    #   Vault.auth.tls() #=> #<Vault::Secret lease_id="">
+    #   Vault.auth.tls("/path/to/my/certificate.pem") #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] pem_file (default: the clients' configured ssl_pem_file)
+    #   the pem_file to use for the login procedure
+    #
+    # @return [Secret]
+    def tls(pem_file = nil)
+      old_pem_file = client.ssl_pem_file
+      client.ssl_pem_file = pem_file || old_pem_file
+
+      json = client.post("/v1/auth/cert/login")
+      secret = Secret.decode(json)
+      client.token = secret.auth.client_token
+      return secret
+    ensure
+      # reset ssl pem file
+      client.ssl_pem_file = old_pem_file
+    end
   end
 end

--- a/lib/vault/api/auth_tls.rb
+++ b/lib/vault/api/auth_tls.rb
@@ -1,0 +1,92 @@
+require "json"
+
+require_relative "secret"
+require_relative "../client"
+require_relative "../request"
+require_relative "../response"
+
+module Vault
+  class Certificate < Response.new(:display_name, :certificate, :policies, :ttl); end
+
+  class Client
+    # A proxy to the {AuthToken} methods.
+    # @return [AuthToken]
+    def auth_tls
+      @auth_tls ||= AuthTLS.new(self)
+    end
+  end
+
+  class AuthTLS < Request
+
+    # This enables the auth tls cert backend
+    def enable
+      client.sys.enable_auth('cert', 'cert', 'Allow to login via TLS certificate')
+    end
+
+    # This disable the auth tls cert backend
+    def disable
+      client.sys.disable_auth('cert')
+    end
+
+    # The list of certificates in vault auth backend.
+    #
+    # @example
+    #   Vault.auth_tls.certificates #=> ["web"]
+    #
+    # @return [Array<String>]
+    def certificates
+      json = client.get("/v1/auth/cert/certs", list: true)
+      json[:data][:keys] || []
+    rescue HTTPError => e
+      return [] if e.code == 404
+      raise
+      []
+    end
+
+    # Get the certificate by the given name. If a certificate does not exist by that name,
+    # +nil+ is returned.
+    #
+    # @example
+    #   Vault.auth_tls.certificate("web")
+    #   #=> #<Vault::Certificate ...>
+    #
+    # @return [Certificate, nil]
+    def certificate(name)
+      json = client.get("/v1/auth/cert/certs/#{CGI.escape(name)}")
+      return Certificate.decode(json[:data])
+    rescue HTTPError => e
+      return nil if e.code == 404
+      raise
+    end
+
+    # Saves a certificate with the given name and attributes.
+    #
+    # @example
+    #   cert = Certificate.new('web-cert', '-----BEGIN CERTIFICATE...', "default", 3600)
+    #   Vault.auth_tls.put_certificate("web", cert) #=> true
+    #
+    # @param [String] name
+    #   the name of the certificate
+    # @param [Vault::Certificate] certificate
+    #   the certificate defintion
+    #
+    # @return [true]
+    def put_certificate(name, certificate)
+      client.post("/v1/auth/cert/certs/#{CGI.escape(name)}", JSON.fast_generate(certificate.to_h))
+      return true
+    end
+
+    # Delete the certificate with the given name. If a certificate does not exist, vault
+    # will not return an error.
+    #
+    # @example
+    #   Vault.auth_tls.delete_certificate("web") #=> true
+    #
+    # @param [String] name
+    #   the name of the certificate
+    def delete_certificate(name)
+      client.delete("/v1/auth/cert/certs/#{CGI.escape(name)}")
+      return true
+    end
+  end
+end

--- a/lib/vault/api/auth_tls.rb
+++ b/lib/vault/api/auth_tls.rb
@@ -6,11 +6,34 @@ require_relative "../request"
 require_relative "../response"
 
 module Vault
-  class Certificate < Response.new(:display_name, :certificate, :policies, :ttl); end
+  class Certificate < Response
+    # @!attribute [r] display_name
+    #   Display name for the certificate.
+    #   @return [String]
+    field :display_name
+
+    # @!attribute [r] certificate
+    #   The raw tls certificate.
+    #   @return [String]
+    field :certificate
+
+    # @!attribute [r] policies
+    #   List of policies assigned to this certificate.
+    #
+    #   @example "production, staging"
+    #
+    #   @return [String]
+    field :policies
+
+    # @!attribute [r] ttl
+    #   The ttl until the certificate expires.
+    #   @return [Fixnum]
+    field :ttl
+  end
 
   class Client
-    # A proxy to the {AuthToken} methods.
-    # @return [AuthToken]
+    # A proxy to the {AuthTLS} methods.
+    # @return [AuthTLS]
     def auth_tls
       @auth_tls ||= AuthTLS.new(self)
     end
@@ -65,7 +88,7 @@ module Vault
     # Saves a certificate with the given name and attributes.
     #
     # @example
-    #   cert = Certificate.new('web-cert', '-----BEGIN CERTIFICATE...', "default", 3600)
+    #   cert = Certificate.new(display_name: 'web-cert', certificate: '-----BEGIN CERTIFICATE...', policies: "default", ttl: 3600)
     #   Vault.auth_tls.put_certificate("web", cert) #=> true
     #
     # @param [String] name

--- a/lib/vault/api/auth_tls.rb
+++ b/lib/vault/api/auth_tls.rb
@@ -23,6 +23,10 @@ module Vault
       client.sys.enable_auth('cert', 'cert', 'Allow to login via TLS certificate')
     end
 
+    def enabled?
+      client.sys.auths.keys.include? :cert
+    end
+
     # This disable the auth tls cert backend
     def disable
       client.sys.disable_auth('cert')

--- a/lib/vault/api/auth_tls.rb
+++ b/lib/vault/api/auth_tls.rb
@@ -20,7 +20,7 @@ module Vault
 
     # This enables the auth tls cert backend
     def enable
-      client.sys.enable_auth('cert', 'cert', 'Allow to login via TLS certificate')
+      client.sys.enable_auth('cert', 'cert', 'Allow login via TLS certificate')
     end
 
     def enabled?
@@ -44,7 +44,6 @@ module Vault
     rescue HTTPError => e
       return [] if e.code == 404
       raise
-      []
     end
 
     # Get the certificate by the given name. If a certificate does not exist by that name,
@@ -72,7 +71,7 @@ module Vault
     # @param [String] name
     #   the name of the certificate
     # @param [Vault::Certificate] certificate
-    #   the certificate defintion
+    #   the certificate definition
     #
     # @return [true]
     def put_certificate(name, certificate)

--- a/lib/vault/response.rb
+++ b/lib/vault/response.rb
@@ -62,5 +62,16 @@ module Vault
         end
       end
     end
+
+    def ==(other)
+      to_h == other.to_h
+    end
+
+    def to_h
+      self.class.fields.inject({}) do |hash, (k, _)|
+        hash[k] = public_send(k)
+        hash
+      end
+    end
   end
 end

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -100,8 +100,13 @@ module Vault
       before(:context) { vault_test_client.auth_tls.enable }
       after(:context) { vault_test_client.auth_tls.disable }
 
-      let(:certificate) { Certificate.new('kaelumania-cert', RSpec::SampleCertificate.cert, "default", 3600) }
       let!(:old_token) { subject.token }
+      let(:certificate) do
+        Certificate.new(display_name: 'kaelumania-cert',
+                        certificate: RSpec::SampleCertificate.cert,
+                        policies: "default",
+                        ttl: 3600)
+      end
 
       before do
         allow(File).to receive(:read).with('kaelumania.pem') { RSpec::SampleCertificate.cert << RSpec::SampleCertificate.key }

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -95,5 +95,48 @@ module Vault
         }.to_not change(subject, :token)
       end
     end
+
+    describe "#tls" do
+      before(:context) { vault_test_client.auth_tls.enable }
+      after(:context) { vault_test_client.auth_tls.disable }
+
+      let(:certificate) { Certificate.new('kaelumania-cert', RSpec::SampleCertificate.cert, "default", 3600) }
+      let!(:old_token) { subject.token }
+
+      before do
+        allow(File).to receive(:read).with('kaelumania.pem') { RSpec::SampleCertificate.cert << RSpec::SampleCertificate.key }
+      end
+
+      after do
+        subject.token = old_token
+      end
+
+      it "authenticates and saves the token on the client" do
+        pending
+
+        subject.auth_tls.put_certificate('kaelumania', certificate)
+
+        result = subject.auth.tls('kaelumania.pem')
+        expect(subject.token).to eq(result.auth.client_token)
+      end
+
+      it "authenticates with default ssl_pem_file" do
+        pending
+
+        subject.auth_tls.put_certificate('kaelumania', certificate)
+        subject.ssl_pem_file = 'kaelumania.pem'
+
+        result = subject.auth.tls
+        expect(subject.token).to eq(result.auth.client_token)
+      end
+
+      it "raises an error if the authentication is bad" do
+        expect {
+          expect {
+            subject.auth.tls('kaelumania.pem')
+          }.to raise_error(HTTPError)
+        }.to_not change(subject, :token)
+      end
+    end
   end
 end

--- a/spec/integration/api/auth_tls_spec.rb
+++ b/spec/integration/api/auth_tls_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+require 'pry'
+
+module Vault
+  describe AuthTLS do
+    subject { vault_test_client.auth_tls }
+
+    before(:context) { vault_test_client.auth_tls.enable }
+    after(:context) { vault_test_client.auth_tls.disable }
+
+    describe "certificates" do
+      let(:certificate) { Certificate.new('kaelumania-cert', RSpec::SampleCertificate.cert, "default", 3600) }
+
+      it 'can be added' do
+        expect(subject.put_certificate('kaelumania', certificate)).to be_truthy
+        expect(subject.certificate('kaelumania')).to eq certificate
+      end
+
+      it 'can be deleted' do
+        expect(subject.put_certificate('kaelumania', certificate)).to be_truthy
+        expect(subject.delete_certificate('kaelumania')).to be_truthy
+        expect(subject.certificate('kaelumania')).to be_nil
+      end
+
+      it 'can be listed' do
+        pending
+
+        expect(subject.put_certificate('kaelumania', certificate)).to be_truthy
+        expect(subject.certificates).to include 'kaelumania'
+      end
+    end
+  end
+end

--- a/spec/integration/api/auth_tls_spec.rb
+++ b/spec/integration/api/auth_tls_spec.rb
@@ -10,7 +10,12 @@ module Vault
     after(:context) { vault_test_client.auth_tls.disable }
 
     describe "certificates" do
-      let(:certificate) { Certificate.new('kaelumania-cert', RSpec::SampleCertificate.cert, "default", 3600) }
+      let(:certificate) do
+        Certificate.new(display_name: 'kaelumania-cert',
+                        certificate: RSpec::SampleCertificate.cert,
+                        policies: "default",
+                        ttl: 3600) 
+      end 
 
       it 'can be added' do
         expect(subject.put_certificate('kaelumania', certificate)).to be_truthy
@@ -24,8 +29,6 @@ module Vault
       end
 
       it 'can be listed' do
-        pending
-
         expect(subject.put_certificate('kaelumania', certificate)).to be_truthy
         expect(subject.certificates).to include 'kaelumania'
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require "webmock/rspec"
 
 require_relative "support/vault_server"
 require_relative "support/redirect_server"
+require_relative "support/sample_certificate"
 
 RSpec.configure do |config|
   # Custom helper modules and extensions

--- a/spec/support/sample_certificate.rb
+++ b/spec/support/sample_certificate.rb
@@ -1,0 +1,67 @@
+module RSpec
+  class SampleCertificate
+
+    def self.cert
+      <<-EOH.gsub(/^\s*/,'')
+        -----BEGIN CERTIFICATE-----
+        MIIETjCCAzagAwIBAgIJALOl5x95gXuxMA0GCSqGSIb3DQEBBQUAMHcxCzAJBgNV
+        BAYTAkRFMQwwCgYDVQQIEwNOUlcxETAPBgNVBAcUCE3DvG5zdGVyMRMwEQYDVQQK
+        EwprYWVsdW1hbmlhMRMwEQYDVQQLEwprYWVsdW1hbmlhMR0wGwYDVQQDFBRrYWxl
+        dW1hbmlhQGdtYWlsLmNvbTAeFw0xNjAzMTgwOTI5NThaFw0xNjA0MTcwOTI5NTha
+        MHcxCzAJBgNVBAYTAkRFMQwwCgYDVQQIEwNOUlcxETAPBgNVBAcUCE3DvG5zdGVy
+        MRMwEQYDVQQKEwprYWVsdW1hbmlhMRMwEQYDVQQLEwprYWVsdW1hbmlhMR0wGwYD
+        VQQDFBRrYWxldW1hbmlhQGdtYWlsLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEP
+        ADCCAQoCggEBAKmPsgiAKCsOwoSGwkHWZHsp4D4ldA/5gjXIssdnH7wMfCusb69C
+        NZafLxAzYqVuSoHT34s8p+cdi4zPeGJaZLqjZ9lrVT77jLhnU81lJIYmaR0puyag
+        9s1QG5UwNulryOvqrXeBM3BPn+3+46jchuIZVRdqIv13a6ho8PyatrbWCxiOAOtP
+        TmZOlhxWK4K/eQc5Fq/M0zgbDnVYlyWDNcqhDsB55ZrMW4n80/Bo6nCVkR+xTktw
+        1eQdH+xWsHTpRVL/ooKImx0pGVy3JtIXn7ic6DCvD9OcndUumgL1DqAA35EJxRSi
+        mveKz/d1YdkBEKM5UbJ6afv5/vONWKiKUKkCAwEAAaOB3DCB2TAdBgNVHQ4EFgQU
+        dgcSZJbWM1LiYCInPBB2j1JKrwkwgakGA1UdIwSBoTCBnoAUdgcSZJbWM1LiYCIn
+        PBB2j1JKrwmhe6R5MHcxCzAJBgNVBAYTAkRFMQwwCgYDVQQIEwNOUlcxETAPBgNV
+        BAcUCE3DvG5zdGVyMRMwEQYDVQQKEwprYWVsdW1hbmlhMRMwEQYDVQQLEwprYWVs
+        dW1hbmlhMR0wGwYDVQQDFBRrYWxldW1hbmlhQGdtYWlsLmNvbYIJALOl5x95gXux
+        MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAE+NAippU66HkqbIz/vy
+        e47CJeTwFlfewisWhuWxnxMgKjYVg7u6TzabofraTkbcbShfxKiiI6SFY75NVGTv
+        dpzR1W7HNjqoZ4coXC/oe9FGOQsrDDrwjOHuZybMOERxXQJtWnE4IgWJBzZEeyhZ
+        XnQA6RAnkLIES9RXLnRnb84oYJk7xggIBF6rp08ykuBItjkOsYoouWcPd1w/7sHs
+        yi4B7AOJdlSQ2iHwF0Ulvh84Sp+Q0X6wWbURvkrCYHE/y9YTS0Umt6umHfNzyljx
+        euEvWAzkbmKvPr92F8hjOaLqUJyPSGnB0b/vsejt/WKWbW0IKI9xcWLC1lfc6MJo
+        wrM=
+        -----END CERTIFICATE-----
+      EOH
+    end
+
+    def self.key
+      <<-EOH.gsub(/^\s*/,'')
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpAIBAAKCAQEAqY+yCIAoKw7ChIbCQdZkeyngPiV0D/mCNciyx2cfvAx8K6xv
+        r0I1lp8vEDNipW5KgdPfizyn5x2LjM94YlpkuqNn2WtVPvuMuGdTzWUkhiZpHSm7
+        JqD2zVAblTA26WvI6+qtd4EzcE+f7f7jqNyG4hlVF2oi/XdrqGjw/Jq2ttYLGI4A
+        609OZk6WHFYrgr95BzkWr8zTOBsOdViXJYM1yqEOwHnlmsxbifzT8GjqcJWRH7FO
+        S3DV5B0f7FawdOlFUv+igoibHSkZXLcm0hefuJzoMK8P05yd1S6aAvUOoADfkQnF
+        FKKa94rP93Vh2QEQozlRsnpp+/n+841YqIpQqQIDAQABAoIBAQCZNGPJOHqSxQhO
+        lDBLKnqpqiGaJV8j2+6hyBB5CR1sXN+I2oojEbC3wmbUvYkhLnEVsylldk3DDjf7
+        562/OCuRU3nOwiNJACKar4nRqNSCfYw2NHGMKp40zm/Nsb271I67UtSfiNbAYMGB
+        We+7sF4TRo5S1Kx+1nsotIEhzGzQ70Z9HDPZoye6lNZDPn9jmmitdGPDfeOknBTn
+        cZg6+czU3jQZ5Xk1NUrBirEhMC5xhykMK3KPj/Yj7MbQrtcRpFh/sRl0mVQ7BYo0
+        eba+3zMChoQ7IYb9AzJQZDr4u+uhiHMSzzJVxmvbPKsck42jRBvYJmk+NDDpSyUH
+        qPVbyR2BAoGBANYhZMLpLt+WmIn7pRNcACsSvfEsFpiZiQOdxv+/Cu7JreeG1BnW
+        qxtoqGcj7nHupCj8rx5bB/kQUufDLHpDaINVhI/iFjgp5WQX4lIx32sTv7jAiqUf
+        EssmSRxbTqtdsZVkeAXINmnk+S08ZDcxvvA/mDegkwai+jkiaNb5USB5AoGBAMq3
+        VHhpWACG5ZhMpab/wcfPZEsCqAN8yR9U91TUJ4L6GyJzsFcBeFMnMuQhB+BiELIh
+        t9QyIQvhvuOqZpHB3MgK4m6Pv0NOmRdDcIxJfLdjZj7lJsf2rbwQ2qjaTSZ/l1Vv
+        W5OakOf4+AIau6BT/neuxS6Kxm+Y+49839CRNIWxAoGAXSNlSopWwxYj/1Cfus33
+        nMSoLbC5m2KdAB+uoSsdvEOpCt3Qf/SptGBPb51nZ9MfQFy4ZwG9dA4voXN5cyzC
+        1u1pnZP/iipfBqyE2q+quE58xAWryKq9Z/OdNWJZ05wLVCnBMvKlCGZ6I7zy8jcH
+        EET5FqkXinl1UUiwRWFocjECgYEAr6apX+jP4y0ANrZ7dzf33j3bRo/Xq6Xt0+NY
+        qL1oOzqiVnjuHIXekBbQJxJj886lbuR+mDSTo+sI79bQJ45W01NzHqAZ96VcS+cY
+        18Y5deKATxFaSDx8EBB+l38JCMnYBKSIMl7lHswBgjlNyL/fKC9dFlYTWdGycIOg
+        n+WiIBECgYATmx5+Uqtyz20WpSAY5QD2A+/Jnsth3YAYThYCfoUE0dJrWxI1fmUs
+        4dFt+QScfSPIWNAkPjeQinXerflrze/3FkmZ+X21fao33Ymq+RvT+O8Wsz6FmMR0
+        wyEvPHSgjDQ0jEwyRd8PhhZa13Zj2XoteoBwTRea20WSKetbUxI88A==
+        -----END RSA PRIVATE KEY-----
+      EOH
+    end
+  end
+end


### PR DESCRIPTION
Implements: https://github.com/hashicorp/vault-ruby/issues/23

I was unable to come up with integration specs for the auth part, because the vault dev server does not support tls. Further I didn't implement the`crl` and `config` functionality for the `auth/cert/` path.