### PR TITLE
Reverse VAULT_SKIP_VERIFY logic

### DIFF
--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -128,7 +128,7 @@ module Vault
       def ssl_verify
         # Vault CLI uses this envvar, so accept it by precedence
         if !ENV["VAULT_SKIP_VERIFY"].nil?
-          return true
+          return false
         end
 
         if ENV["VAULT_SSL_VERIFY"].nil?

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -158,7 +158,7 @@ module Vault
 
       it "reads the value of ENV['VAULT_SKIP_VERIFY']" do
         with_stubbed_env("VAULT_SKIP_VERIFY" => true) do
-          expect(Defaults.ssl_verify).to be(true)
+          expect(Defaults.ssl_verify).to be(false)
         end
       end
 


### PR DESCRIPTION
It seems like this logic is reversed. If `VAULT_SKIP_VERIFY` is set, we should skip verification by returning false from `ssl_verify`.