### PR TITLE
Add support for creating tokens using roles

### DIFF
--- a/lib/vault/api/auth_token.rb
+++ b/lib/vault/api/auth_token.rb
@@ -24,7 +24,12 @@ module Vault
     #
     # @return [Secret]
     def create(options = {})
-      json = client.post("/v1/auth/token/create", JSON.fast_generate(options))
+      url = if options.include?(:role)
+              "/v1/auth/token/create/" + options.delete(:role)
+            else
+              "/v1/auth/token/create"
+            end
+      json = client.post(url, JSON.fast_generate(options))
       return Secret.decode(json)
     end
 

--- a/spec/integration/api/auth_token_spec.rb
+++ b/spec/integration/api/auth_token_spec.rb
@@ -5,8 +5,19 @@ module Vault
     subject { vault_test_client }
 
     describe "#create" do
+      before(:context) do
+        vault_test_client.logical.write("auth/token/roles/default")
+      end
+
       it "creates a new token" do
         result = subject.auth_token.create
+        expect(result).to be_a(Vault::Secret)
+        expect(result.auth).to be_a(Vault::SecretAuth)
+        expect(result.auth.client_token).to be
+      end
+
+      it "creates a new token using a role" do
+        result = subject.auth_token.create(role: 'default')
         expect(result).to be_a(Vault::Secret)
         expect(result.auth).to be_a(Vault::SecretAuth)
         expect(result.auth.client_token).to be


### PR DESCRIPTION
If a role option is passed to auth_token.create, use it to construct the endpoint URL (similar to the syntax in the vault CLI).