### PR TITLE
Support passing pgp_keys to 'init'

### DIFF
--- a/lib/vault/api/sys/init.rb
+++ b/lib/vault/api/sys/init.rb
@@ -33,12 +33,15 @@ module Vault
     #   the number of shares
     # @option options [Fixnum] :threshold
     #   the number of keys needed to unlock
+    # @options options [Array] :pgp_keys
+    #   an optional Array of base64-encoded PGP public keys to encrypt shares with
     #
     # @return [InitResponse]
     def init(options = {})
       json = client.put("/v1/sys/init", JSON.fast_generate(
         secret_shares:    options.fetch(:shares, 5),
         secret_threshold: options.fetch(:threshold, 3),
+        pgp_keys:         options.fetch(:pgp_keys, nil)
       ))
       return InitResponse.decode(json)
     end


### PR DESCRIPTION
Adds support for the `pgp_keys` option to `/sys/init`. The specs currently skip init, so couldn't add that, but I verified it was working in local tests.
