### PR TITLE
Add implementation for the `/sys/mounts/<mount_point>/tune` endpoint.

### DIFF
--- a/lib/vault/api/sys/mount.rb
+++ b/lib/vault/api/sys/mount.rb
@@ -3,7 +3,7 @@ require "json"
 require_relative "../sys"
 
 module Vault
-  class Mount < Response.new(:type, :description); end
+  class Mount < Response.new(:type, :description, :config); end
 
   class Sys < Request
     # List all mounts in the vault.
@@ -35,6 +35,20 @@ module Vault
       payload[:description] = description if !description.nil?
 
       client.post("/v1/sys/mounts/#{CGI.escape(path)}", JSON.fast_generate(payload))
+      return true
+    end
+
+    # Tune a mount at the given path.
+    #
+    # @example
+    #   Vault.sys.mount_tune("pki", max_lease_ttl: '87600h') #=> true
+    #
+    # @param [String] path
+    #   the path to write
+    # @param [Hash] data
+    #   the data to write
+    def mount_tune(path, data = {})
+      json = client.post("/v1/sys/mounts/#{CGI.escape(path)}/tune", JSON.fast_generate(data))
       return true
     end
 

--- a/spec/integration/api/sys/mount_spec.rb
+++ b/spec/integration/api/sys/mount_spec.rb
@@ -24,6 +24,16 @@ module Vault
       end
     end
 
+    describe "#mount_tune" do
+      it "tunes the mount" do
+        expect(subject.mount("test_mount_tune", "aws")).to be(true)
+        expect(subject.mount_tune("test_mount_tune", max_lease_ttl: '1234h'))
+        result = subject.mounts[:test_mount_tune]
+        expect(result).to be_a(Mount)
+        expect(result.config[:max_lease_ttl]).to eq(1234*60*60)
+      end
+    end
+
     describe "#unmount" do
       it "unmounts by name" do
         subject.mount("test_unmount", "aws")


### PR DESCRIPTION
Adds the ability to tune mounts, which also necessitated adding `config` to the `Vault::Mount` struct that gets returned.
