### PR TITLE
remove recursive requires

### DIFF
--- a/lib/vault/api/sys/audit.rb
+++ b/lib/vault/api/sys/audit.rb
@@ -1,7 +1,5 @@
 require "json"
 
-require_relative "../sys"
-
 module Vault
   class Audit < Response.new(:type, :description, :options); end
 

--- a/lib/vault/api/sys/auth.rb
+++ b/lib/vault/api/sys/auth.rb
@@ -1,7 +1,5 @@
 require "json"
 
-require_relative "../sys"
-
 module Vault
   class Auth < Response.new(:type, :description); end
 

--- a/lib/vault/api/sys/init.rb
+++ b/lib/vault/api/sys/init.rb
@@ -1,7 +1,5 @@
 require "json"
 
-require_relative "../sys"
-
 module Vault
   class InitResponse < Response.new(:keys, :root_token); end
 

--- a/lib/vault/api/sys/leader.rb
+++ b/lib/vault/api/sys/leader.rb
@@ -1,5 +1,3 @@
-require_relative "../sys"
-
 module Vault
   class LeaderStatus < Response.new(:ha_enabled, :is_self, :leader_address)
     alias_method :ha_enabled?, :ha_enabled

--- a/lib/vault/api/sys/lease.rb
+++ b/lib/vault/api/sys/lease.rb
@@ -1,5 +1,3 @@
-require_relative "../sys"
-
 module Vault
   class Sys
     # Renew a lease with the given ID.

--- a/lib/vault/api/sys/mount.rb
+++ b/lib/vault/api/sys/mount.rb
@@ -1,7 +1,5 @@
 require "json"
 
-require_relative "../sys"
-
 module Vault
   class Mount < Response.new(:type, :description, :config); end
 

--- a/lib/vault/api/sys/policy.rb
+++ b/lib/vault/api/sys/policy.rb
@@ -1,7 +1,5 @@
 require "json"
 
-require_relative "../sys"
-
 module Vault
   class Policy < Response.new(:rules); end
 

--- a/lib/vault/api/sys/seal.rb
+++ b/lib/vault/api/sys/seal.rb
@@ -1,7 +1,5 @@
 require "json"
 
-require_relative "../sys"
-
 module Vault
   class SealStatus < Response.new(:sealed, :t, :n, :progress)
     alias_method :sealed?, :sealed


### PR DESCRIPTION
I am getting a long recurise output when running tests in a gem that includes another gem that requires vault

here is the output...

```
/home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/audit.rb:3: warning: loading in progress, circular require considered harmful - /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `<main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `select'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `block in <main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `require'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `<top (required)>'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `require_relative'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `<top (required)>'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `require'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `<top (required)>'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `<module:Vault>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:2:in  `<module:Vault>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `<module:API>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:17:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:17:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/audit.rb:3:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/audit.rb:3:in  `require_relative'
/home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/auth.rb:3: warning: loading in progress, circular require considered harmful - /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `<main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `select'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `block in <main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `require'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `<top (required)>'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `require_relative'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `<top (required)>'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `require'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `<top (required)>'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `<module:Vault>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:2:in  `<module:Vault>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `<module:API>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:18:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:18:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/auth.rb:3:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/auth.rb:3:in  `require_relative'
/home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/init.rb:3: warning: loading in progress, circular require considered harmful - /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `<main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `select'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `block in <main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `require'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `<top (required)>'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `require_relative'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `<top (required)>'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `require'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `<top (required)>'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `<module:Vault>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:2:in  `<module:Vault>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `<module:API>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:19:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:19:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/init.rb:3:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/init.rb:3:in  `require_relative'
/home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/leader.rb:1: warning: loading in progress, circular require considered harmful - /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `<main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `select'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `block in <main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `require'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `<top (required)>'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `require_relative'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `<top (required)>'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `require'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `<top (required)>'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `<module:Vault>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:2:in  `<module:Vault>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `<module:API>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:20:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:20:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/leader.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/leader.rb:1:in  `require_relative'
/home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/lease.rb:1: warning: loading in progress, circular require considered harmful - /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `<main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `select'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `block in <main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `require'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `<top (required)>'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `require_relative'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `<top (required)>'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `require'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `<top (required)>'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `<module:Vault>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:2:in  `<module:Vault>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `<module:API>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:21:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:21:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/lease.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/lease.rb:1:in  `require_relative'
/home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/mount.rb:3: warning: loading in progress, circular require considered harmful - /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `<main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `select'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `block in <main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `require'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `<top (required)>'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `require_relative'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `<top (required)>'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `require'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `<top (required)>'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `<module:Vault>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:2:in  `<module:Vault>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `<module:API>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:22:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:22:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/mount.rb:3:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/mount.rb:3:in  `require_relative'
/home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/policy.rb:3: warning: loading in progress, circular require considered harmful - /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `<main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `select'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `block in <main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `require'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `<top (required)>'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `require_relative'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `<top (required)>'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `require'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `<top (required)>'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `<module:Vault>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:2:in  `<module:Vault>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `<module:API>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:23:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:23:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/policy.rb:3:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/policy.rb:3:in  `require_relative'
/home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/seal.rb:3: warning: loading in progress, circular require considered harmful - /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `<main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:4:in  `select'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `block in <main>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/rake-11.2.2/lib/rake/rake_test_loader.rb:15:in  `require'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `<top (required)>'
        from /home/mathieu/gem_one/test/models/access_token_spec.rb:1:in  `require_relative'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `<top (required)>'
        from /home/mathieu/gem_one/test/helper.rb:7:in  `require'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `<top (required)>'
        from /home/mathieu/gem_one/lib/gem_one.rb:29:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two.rb:6:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/bundler/gems/gem_two-0200e44a312f/lib/gem_two/vault_client.rb:4:in  `require'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `<module:Vault>'
        from /home/mathieu/.rvm/gems/ruby-2.3.1/gems/vault-0.4.0/lib/vault.rb:9:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:1:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:2:in  `<module:Vault>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `<module:API>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api.rb:8:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:24:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys.rb:24:in  `require_relative'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/seal.rb:3:in  `<top (required)>'
        from /home/mathieu/.rvm/rubies/ruby-2.3.1/lib/ruby/gems/2.3.0/gems/vault-0.4.0/lib/vault/api/sys/seal.rb:3:in  `require_relative'
```

removing these required fix the issue
