### PR TITLE
must bump to be greated than 0.4.0

### DIFF
--- a/lib/vault/version.rb
+++ b/lib/vault/version.rb
@@ -1,3 +1,3 @@
 module Vault
-  VERSION = "0.4.0.dev"
+  VERSION = "0.4.1.dev"
 end


### PR DESCRIPTION
Since 0.4.0 already got released.
0.4.0.dev is considered lower than 0.4.0
so if one's app require '>= 0.4.0' and suddenly want to use the latest master.
that requirement won't match