### PR TITLE
Added support for response wrapping and unwrapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,26 @@ secret = Vault.logical.read("secret/bacon")
 secret.data #=> { :cooktime = >"11", :delicious => true }
 ```
 
+### Response wrapping
+```ruby
+# Request new access token as wrapped response where the ttl of the temporary token is 500
+wrapped_token_response = Vault.auth_token.create(wrap_ttl: 500)
+# Unwrap wrapped response for final token using the initial temporary token
+unwrapped_token_response = Vault.logical.unwrap(wrapped_token_response.wrap_info.token)
+# Extract final token from response
+unwrapped_token = unwrapped_token_response.data.auth.client_token
+```
+
+If the above detail is unnecessary there is a helper method 'unwrap_token' available
+
+```ruby
+# Request new access token as wrapped response where the ttl of the temporary token is 500
+wrapped_token_response = Vault.auth_token.create(wrap_ttl: 500)
+# Unwrap wrapped response for final token using the initial temporary token
+unwrapped_token = Vault.logical.unwrap_token(wrapped_token_response)
+```
+
+
 Development
 -----------
 1. Clone the project on GitHub
@@ -168,3 +188,4 @@ Important Notes:
 - **All new features must include test coverage.** At a bare minimum, Unit tests are required. It is preferred if you include acceptance tests as well.
 - **The tests must be be idempotent.** The HTTP calls made during a test should be able to be run over and over.
 - **Tests are order independent.** The default RSpec configuration randomizes the test order, so this should not be a problem.
+- **Integration tests require Vault**  Vault must be available in the path for the integration tests to pass.

--- a/lib/vault/api/auth_token.rb
+++ b/lib/vault/api/auth_token.rb
@@ -19,12 +19,14 @@ module Vault
     #
     # @example
     #   Vault.auth_token.create #=> #<Vault::Secret lease_id="">
+    #   Vault.auth_token.create({"policies":["myapp"],"display_name":"","num_uses":0,"renewable":true, wrap_ttl:500})
     #
     # @param [Hash] options
     #
     # @return [Secret]
     def create(options = {})
-      json = client.post("/v1/auth/token/create", JSON.fast_generate(options))
+      headers = options[:wrap_ttl].nil? ? {} : { Vault::Client::WRAP_TTL_HEADER => options.delete(:wrap_ttl) }
+      json = client.post("/v1/auth/token/create", JSON.fast_generate(options), headers)
       return Secret.decode(json)
     end
 
@@ -37,7 +39,8 @@ module Vault
     #
     # @return [Secret]
     def create_orphan(options = {})
-      json = client.post("/v1/auth/token/create-orphan", JSON.fast_generate(options))
+      headers = options[:wrap_ttl].nil? ? {} : { Vault::Client::WRAP_TTL_HEADER => options.delete(:wrap_ttl) }
+      json = client.post("/v1/auth/token/create-orphan", JSON.fast_generate(options), headers)
       return Secret.decode(json)
     end
 
@@ -50,7 +53,8 @@ module Vault
     #
     # @return [Secret]
     def create_with_role(name, options = {})
-      json = client.post("/v1/auth/token/create/#{CGI.escape(name)}", JSON.fast_generate(options))
+      headers = options[:wrap_ttl].nil? ? {} : { Vault::Client::WRAP_TTL_HEADER => options.delete(:wrap_ttl) }
+      json = client.post("/v1/auth/token/create/#{CGI.escape(name)}", JSON.fast_generate(options), headers)
       return Secret.decode(json)
     end
 
@@ -139,8 +143,8 @@ module Vault
     # @example
     #   Vault.auth_token.revoke_prefix("abcd-1234") #=> true
     #
-    # @param [String] id
-    #   the auth id
+    # @param [String] prefix
+    #   the prefix to revoke
     #
     # @return [true]
     def revoke_prefix(prefix)

--- a/lib/vault/api/secret.rb
+++ b/lib/vault/api/secret.rb
@@ -136,6 +136,16 @@ module Vault
     #   @return [String]
     field :token
 
+    # @!attribute [r] wrapped_accessor
+    #   Accessor for the wrapped token. This is like a `lease_id`, but for a token.
+    #   @return [String]
+    field :wrapped_accessor
+
+    # @!attribute [r] creation_time
+    #   Date & time when the wrapped token was created
+    #   @return [Time]
+    field :creation_time, load: ->(v) { Time.parse(v) }
+
     # @!attribute [r] ttl
     #   The TTL on the token returned in seconds.
     #   @return [Fixnum]

--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -16,6 +16,9 @@ module Vault
     # The name of the header used to hold the Vault token.
     TOKEN_HEADER = "X-Vault-Token".freeze
 
+    # The name of the header used to hold the wrapped request ttl.
+    WRAP_TTL_HEADER = "X-Vault-Wrap-TTL".freeze
+
     # The name of the header used for redirection.
     LOCATION_HEADER = "location".freeze
 
@@ -132,7 +135,7 @@ module Vault
       # Add the Vault token header - users could still override this on a
       # per-request basis
       if !token.nil?
-        request.add_field(TOKEN_HEADER, token)
+        headers[TOKEN_HEADER] ||= token
       end
 
       # Add headers

--- a/spec/integration/api/auth_token_spec.rb
+++ b/spec/integration/api/auth_token_spec.rb
@@ -11,6 +11,15 @@ module Vault
         expect(result.auth).to be_a(Vault::SecretAuth)
         expect(result.auth.client_token).to be
       end
+
+      it "creates a new token as a wrapped response" do
+        ttl = 50
+        result = subject.auth_token.create({:wrap_ttl => ttl})
+        expect(result).to be_a(Vault::Secret)
+        expect(result.wrap_info).to be_a(Vault::WrapInfo)
+        expect(result.wrap_info.ttl).to eq(ttl)
+        expect(result.wrap_info.token).to be
+      end
     end
 
     describe "#create_orphan" do
@@ -19,6 +28,15 @@ module Vault
         expect(result).to be_a(Vault::Secret)
         expect(result.auth).to be_a(Vault::SecretAuth)
         expect(result.auth.client_token).to be
+      end
+
+      it "creates an orphaned token as a wrapped response" do
+        ttl = 50
+        result = subject.auth_token.create_orphan({:wrap_ttl => ttl})
+        expect(result).to be_a(Vault::Secret)
+        expect(result.wrap_info).to be_a(Vault::WrapInfo)
+        expect(result.wrap_info.ttl).to eq(ttl)
+        expect(result.wrap_info.token).to be
       end
     end
 
@@ -29,6 +47,16 @@ module Vault
         expect(result).to be_a(Vault::Secret)
         expect(result.auth).to be_a(Vault::SecretAuth)
         expect(result.auth.client_token).to be
+      end
+
+      it "creates a new token attached to a role as a wrapped response" do
+        ttl = 50
+        vault_test_client.logical.write("auth/token/roles/default")
+        result = subject.auth_token.create_with_role("default", {:wrap_ttl => ttl})
+        expect(result).to be_a(Vault::Secret)
+        expect(result.wrap_info).to be_a(Vault::WrapInfo)
+        expect(result.wrap_info.ttl).to eq(ttl)
+        expect(result.wrap_info.token).to be
       end
     end
 

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake",    "~> 10.0"
   spec.add_development_dependency "rspec",   "~> 3.2"
+  spec.add_development_dependency "yard"
   spec.add_development_dependency "webmock", "~> 1.22"
 end


### PR DESCRIPTION
Added rudimentary support for response wrapping and unwrapping.

Main focus was to facilitate secure introductions.

Probably needs a clearer way to define the ttl at the user API.  Considered putting it in 'options' but thought I'd solicit feedback first.  The auth_token creation methods could also be dried up depending on final approach.

Fixed minor problem with overriding the token header in client.rb.