### PR TITLE
Strip newline from .vault-token

### DIFF
--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -47,7 +47,7 @@ module Vault
         end
 
         if VAULT_DISK_TOKEN.exist? && VAULT_DISK_TOKEN.readable?
-          return VAULT_DISK_TOKEN.read
+          return VAULT_DISK_TOKEN.read.rstrip
         end
 
         nil

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -39,7 +39,7 @@ module Vault
       end
 
       it "uses ~/.vault-token when present" do
-        File.open(token, "w") { |f| f.write("testing") }
+        File.open(token, "w") { |f| f.write("testing\n") }
         expect(Defaults.token).to eq("testing")
       end
 
@@ -50,7 +50,7 @@ module Vault
       end
 
       it "prefers the environment over local token" do
-        File.open(token, "w") { |f| f.write("testing1") }
+        File.open(token, "w") { |f| f.write("testing1\n") }
         with_stubbed_env("VAULT_TOKEN" => "testing2") do
           expect(Defaults.token).to eq("testing2")
         end


### PR DESCRIPTION
By default and according to the POSIX standard, text files are to be terminated with a newline. When a `.vault-token` file has a terminating newline character, vault-ruby is generating a bad request, resulting in an exception being thrown:

```
Vault::HTTPClientError: The Vault server at `http://<snipped>:8200' responded with a 400.
Any additional information the server supplied is shown below:

  * 400 Bad Request: missing required Host header
```

However, the `vault read` command works as expected.

This PR is a small change which strips all trailing whitespace from the token after reading it from the file.