### PR TITLE
Update api backends to handle Vault 0.6.1 data structures

### DIFF
--- a/lib/vault/api/sys/audit.rb
+++ b/lib/vault/api/sys/audit.rb
@@ -27,6 +27,7 @@ module Vault
     # @return [Hash<Symbol, Audit>]
     def audits
       json = client.get("/v1/sys/audit")
+      json = json[:data] if json[:data]
       return Hash[*json.map do |k,v|
         [k.to_s.chomp("/").to_sym, Audit.decode(v)]
       end.flatten]

--- a/lib/vault/api/sys/auth.rb
+++ b/lib/vault/api/sys/auth.rb
@@ -22,6 +22,7 @@ module Vault
     # @return [Hash<Symbol, Auth>]
     def auths
       json = client.get("/v1/sys/auth")
+      json = json[:data] if json[:data]
       return Hash[*json.map do |k,v|
         [k.to_s.chomp("/").to_sym, Auth.decode(v)]
       end.flatten]

--- a/lib/vault/api/sys/mount.rb
+++ b/lib/vault/api/sys/mount.rb
@@ -27,6 +27,7 @@ module Vault
     # @return [Hash<Symbol, Mount>]
     def mounts
       json = client.get("/v1/sys/mounts")
+      json = json[:data] if json[:data]
       return Hash[*json.map do |k,v|
         [k.to_s.chomp("/").to_sym, Mount.decode(v)]
       end.flatten]


### PR DESCRIPTION
Using both v0.4.0 and v0.5.0 of the vault gem, we noticed that the `sys.audits` crashes with Vault 0.6.1.  Here is the crash for the v0.5.0 version with the json at https://github.com/PagerDuty/vault-ruby/blob/5bbacf01b101b340c72c354862a039e5e8a1a3ed/lib/vault/api/sys/audit.rb#L29 being pretty printed:

```
irb(main):001:0> require 'vault'
=> true
irb(main):002:0> Vault::Client.new(address:'https://127.0.0.1:8200', token:'mytoken', ssl_verify: true, ssl_ca_cert: '/etc/vault/certs/mycert.crt').sys.audits
{:"vault/"=>
  {:description=>"",
   :options=>{:facility=>"local0", :tag=>"vault"},
   :path=>"vault/",
   :type=>"syslog"},
 :request_id=>"178f9d54-acb9-9221-3b32-f73bf55dc603",
 :lease_id=>"",
 :renewable=>false,
 :lease_duration=>0,
 :data=>
  {:"vault/"=>
    {:description=>"",
     :options=>{:facility=>"local0", :tag=>"vault"},
     :path=>"vault/",
     :type=>"syslog"}},
 :wrap_info=>nil,
 :warnings=>nil,
 :auth=>nil}
NoMethodError: undefined method `each' for "178f9d54-acb9-9221-3b32-f73bf55dc603":String
       	from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/vault-0.5.0/lib/vault/response.rb:49:in `initialize'
       	from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/vault-0.5.0/lib/vault/response.rb:38:in `new'
       	from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/vault-0.5.0/lib/vault/response.rb:38:in `decode'
       	from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/vault-0.5.0/lib/vault/api/sys/audit.rb:33:in `block in audits'
       	from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/vault-0.5.0/lib/vault/api/sys/audit.rb:32:in `each'
       	from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/vault-0.5.0/lib/vault/api/sys/audit.rb:32:in `map'
       	from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/vault-0.5.0/lib/vault/api/sys/audit.rb:32:in `audits'
       	from (irb):2
       	from /opt/chef/embedded/bin/irb:11:in `<main>'
```

I'm seeing the same issue on the sys.auth and sys.mount calls, and have verified that the patch below fixes all three endpoints.