### PR TITLE
Fix tests to run against Vault 0.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 sudo: false
 
 before_install: |-
-  curl -so vault.zip https://releases.hashicorp.com/vault/0.6.0/vault_0.6.0_linux_amd64.zip
+  curl -so vault.zip https://releases.hashicorp.com/vault/0.6.1/vault_0.6.1_linux_amd64.zip
   unzip vault.zip
   mkdir ~/bin
   mv vault ~/bin

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -30,11 +30,11 @@ module Vault
         @user_id = "3b87be76-95cf-493a-a61b-7d5fc70870ad"
 
         vault_test_client.sys.enable_auth("app-id", "app-id", nil)
-        vault_test_client.logical.write("auth/app-id/map/app-id/#{@app_id}", { value: "root" })
+        vault_test_client.logical.write("auth/app-id/map/app-id/#{@app_id}", { value: "default" })
         vault_test_client.logical.write("auth/app-id/map/user-id/#{@user_id}", { value: @app_id })
 
         vault_test_client.sys.enable_auth("new-app-id", "app-id", nil)
-        vault_test_client.logical.write("auth/new-app-id/map/app-id/#{@app_id}", { value: "root" })
+        vault_test_client.logical.write("auth/new-app-id/map/app-id/#{@app_id}", { value: "default" })
         vault_test_client.logical.write("auth/new-app-id/map/user-id/#{@user_id}", { value: @app_id })
       end
 
@@ -67,10 +67,10 @@ module Vault
         @password = "s3kr3t"
 
         vault_test_client.sys.enable_auth("userpass", "userpass", nil)
-        vault_test_client.logical.write("auth/userpass/users/#{@username}", { password: @password, policies: "root" })
+        vault_test_client.logical.write("auth/userpass/users/#{@username}", { password: @password, policies: "default" })
 
         vault_test_client.sys.enable_auth("new-userpass", "userpass", nil)
-        vault_test_client.logical.write("auth/new-userpass/users/#{@username}", { password: @password, policies: "root" })
+        vault_test_client.logical.write("auth/new-userpass/users/#{@username}", { password: @password, policies: "default" })
       end
 
       before do

--- a/spec/support/vault_server.rb
+++ b/spec/support/vault_server.rb
@@ -48,7 +48,7 @@ module RSpec
           break if !output.empty?
         end
 
-        if output.match(/Unseal Key: (.+)/)
+        if output.match(/Unseal Key \(hex\)   : (.+)/)
           @unseal_token = $1.strip
         else
           raise "Vault did not return an unseal token!"


### PR DESCRIPTION
* Bump the version of Vault in the Travis configuration to 0.6.1
* The regex extracting the unseal key from the dev server's startup
  output is changed to match the updated format.
* The userpass and app-id tests associate with the "default" policy
  instead of "root", since root tokens may no longer be created by
  authentication backends.