### PR TITLE
bring back silently removed to_h on secret

### DIFF
--- a/lib/vault/response.rb
+++ b/lib/vault/response.rb
@@ -62,5 +62,11 @@ module Vault
         end
       end
     end
+
+    def to_h
+      self.class.fields.each_with_object({}) do |(k, _), hash|
+        hash[k] = instance_variable_get(:"@#{k}")
+      end
+    end
   end
 end

--- a/spec/unit/response_spec.rb
+++ b/spec/unit/response_spec.rb
@@ -1,0 +1,38 @@
+require "spec_helper"
+
+module Vault
+  describe Response do
+    let(:response) do
+      Class.new(Response) do
+        field :foo
+        field :bar, as: :baz?
+      end
+    end
+
+    describe ".field" do
+      it "answers to declared field" do
+        expect(response.new.foo).to eq nil
+      end
+
+      it "answers to declared field via :as" do
+        expect(response.new.baz?).to eq nil
+      end
+
+      it "does ot answer to undeclared fields" do
+        expect { response.new.bar }.to raise_error(NoMethodError)
+      end
+    end
+
+    describe "'.fields' "do
+      it "returns all fields" do
+        expect(response.fields.keys).to eq([:foo, :bar])
+      end
+    end
+
+    describe "#to_h" do
+      it "returns all fields as hash" do
+        expect(response.new(foo: 1, bar: 2).to_h).to eq(foo: 1, bar: 2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
... this used to work on 0.4 ... but then broken when upgrading to 0.5 :(

@sethvargo 