### PR TITLE
Add support of AppRole auth backend

### DIFF
--- a/lib/vault/api.rb
+++ b/lib/vault/api.rb
@@ -1,5 +1,6 @@
 module Vault
   module API
+    require_relative "api/approle"
     require_relative "api/auth_token"
     require_relative "api/auth_tls"
     require_relative "api/auth"

--- a/lib/vault/api/approle.rb
+++ b/lib/vault/api/approle.rb
@@ -1,0 +1,207 @@
+require "json"
+
+require_relative "secret"
+require_relative "../client"
+require_relative "../request"
+require_relative "../response"
+
+module Vault
+  class Client
+    # A proxy to the {AppRole} methods.
+    # @return [AppRole]
+    def approle
+      @approle ||= AppRole.new(self)
+    end
+  end
+
+  class AppRole < Request
+    # Creates a new AppRole or update an existing AppRole with the given name
+    # and attributes.
+    #
+    # @example
+    #   Vault.approle.set_role("testrole", {
+    #     secret_id_ttl: "10m",
+    #     token_ttl:     "20m",
+    #     policies:      "default",
+    #     period:        3600,
+    #   }) #=> true
+    #
+    # @param [String] name
+    #   The name of the AppRole
+    # @param [Hash] options
+    # @option options [Boolean] :bind_secret_id
+    #   Require secret_id to be presented when logging in using this AppRole.
+    # @option options [String] :bound_cidr_list
+    #   Comma-separated list of CIDR blocks. Specifies blocks of IP addresses
+    #   which can perform the login operation.
+    # @option options [String] :policies
+    #   Comma-separated list of policies set on tokens issued via this AppRole.
+    # @option options [String] :secret_id_num_uses
+    #   Number of times any particular SecretID can be used to fetch a token
+    #   from this AppRole, after which the SecretID will expire.
+    # @option options [Fixnum, String] :secret_id_ttl
+    #   The number of seconds or a golang-formatted timestamp like "60m" after
+    #   which any SecretID expires.
+    # @option options [Fixnum, String] :token_ttl
+    #   The number of seconds or a golang-formatted timestamp like "60m" to set
+    #   as the TTL for issued tokens and at renewal time.
+    # @option options [Fixnum, String] :token_max_ttl
+    #   The number of seconds or a golang-formatted timestamp like "60m" after
+    #   which the issued token can no longer be renewed.
+    # @option options [Fixnum, String] :period
+    #   The number of seconds or a golang-formatted timestamp like "60m".
+    #   If set, the token generated using this AppRole is a periodic token.
+    #   So long as it is renewed it never expires, but the TTL set on the token
+    #   at each renewal is fixed to the value specified here. If this value is
+    #   modified, the token will pick up the new value at its next renewal.
+    #
+    # @return [true]
+    def set_role(name, options = {})
+      headers = extract_headers!(options)
+      client.post("/v1/auth/approle/role/#{CGI.escape(name)}", JSON.fast_generate(options), headers)
+      return true
+    end
+
+    # Gets the AppRole by the given name. If an AppRole does not exist by that
+    # name, +nil+ is returned.
+    #
+    # @example
+    #   Vault.approle.role("testrole") #=> #<Vault::Secret lease_id="...">
+    #
+    # @return [Secret, nil]
+    def role(name)
+      json = client.get("/v1/auth/approle/role/#{CGI.escape(name)}")
+      return Secret.decode(json)
+    rescue HTTPError => e
+      return nil if e.code == 404
+      raise
+    end
+
+    # Gets the list of AppRoles in vault auth backend.
+    #
+    # @example
+    #   Vault.approle.roles #=> ["testrole"]
+    #
+    # @return [Array<String>]
+    def roles(options = {})
+      headers = extract_headers!(options)
+      json = client.list("/v1/auth/approle/role", options, headers)
+      return Secret.decode(json).data[:keys] || []
+    rescue HTTPError => e
+      return [] if e.code == 404
+      raise
+    end
+
+    # Reads the RoleID of an existing AppRole. If an AppRole does not exist by
+    # that name, +nil+ is returned.
+    #
+    # @example
+    #   Vault.approle.role_id("testrole") #=> #<Vault::Secret lease_id="...">
+    #
+    # @return [Secret, nil]
+    def role_id(name)
+      json = client.get("/v1/auth/approle/role/#{CGI.escape(name)}/role-id")
+      return Secret.decode(json).data[:role_id]
+    rescue HTTPError => e
+      return nil if e.code == 404
+      raise
+    end
+
+    # Updates the RoleID of an existing AppRole to a custom value.
+    #
+    # @example
+    #   Vault.approle.set_role_id("testrole") #=> true
+    #
+    # @return [true]
+    def set_role_id(name, role_id)
+      options = { role_id: role_id }
+      client.post("/v1/auth/approle/role/#{CGI.escape(name)}/role-id", JSON.fast_generate(options))
+      return true
+    end
+
+    # Deletes the AppRole with the given name. If an AppRole does not exist,
+    # vault will not return an error.
+    #
+    # @example
+    #   Vault.approle.delete_role("testrole") #=> true
+    #
+    # @param [String] name
+    #   the name of the certificate
+    def delete_role(name)
+      client.delete("/v1/auth/approle/role/#{CGI.escape(name)}")
+      return true
+    end
+
+    # Generates and issues a new SecretID on an existing AppRole.
+    #
+    # @example Generate a new SecretID
+    #   result = Vault.approle.create_secret_id("testrole") #=> #<Vault::Secret lease_id="...">
+    #   result.data[:secret_id] #=> "841771dc-11c9-bbc7-bcac-6a3945a69cd9"
+    #
+    # @example Assign a custom SecretID
+    #   result = Vault.approle.create_secret_id("testrole", {
+    #     secret_id: "testsecretid"
+    #   }) #=> #<Vault::Secret lease_id="...">
+    #   result.data[:secret_id] #=> "testsecretid"
+    #
+    # @param [String] role_name
+    #   The name of the AppRole
+    # @param [Hash] options
+    # @option options [String] :secret_id
+    #   SecretID to be attached to the Role. If not set, then the new SecretID
+    #   will be generated
+    # @option options [Hash<String, String>] :metadata
+    #   Metadata to be tied to the SecretID. This should be a JSON-formatted
+    #   string containing the metadata in key-value pairs. It will be set on
+    #   tokens issued with this SecretID, and is logged in audit logs in
+    #   plaintext.
+    #
+    # @return [true]
+    def create_secret_id(role_name, options = {})
+      headers = extract_headers!(options)
+      if options[:secret_id]
+        json = client.post("/v1/auth/approle/role/#{CGI.escape(role_name)}/custom-secret-id", JSON.fast_generate(options), headers)
+      else
+        json = client.post("/v1/auth/approle/role/#{CGI.escape(role_name)}/secret-id", JSON.fast_generate(options), headers)
+      end
+      return Secret.decode(json)
+    end
+
+    # Reads out the properties of a SecretID assigned to an AppRole.
+    # If the specified SecretID don't exist, +nil+ is returned.
+    #
+    # @example
+    #   Vault.approle.role("testrole", "841771dc-11c9-...") #=> #<Vault::Secret lease_id="...">
+    #
+    # @param [String] role_name
+    #   The name of the AppRole
+    # @param [String] secret_id
+    #   SecretID belonging to AppRole
+    #
+    # @return [Secret, nil]
+    def secret_id(role_name, secret_id)
+      json = client.get("/v1/auth/approle/role/#{CGI.escape(role_name)}/secret-id/#{CGI.escape(secret_id)}")
+      return Secret.decode(json)
+    rescue HTTPError => e
+      return nil if e.code == 404
+      raise
+    end
+
+    # Lists the accessors of all the SecretIDs issued against the AppRole.
+    # This includes the accessors for "custom" SecretIDs as well. If there are
+    # no SecretIDs against this role, an empty array will be returned.
+    #
+    # @example
+    #   Vault.approle.secret_ids("testrole") #=> ["ce102d2a-...", "a1c8dee4-..."]
+    #
+    # @return [Array<String>]
+    def secret_id_accessors(role_name, options = {})
+      headers = extract_headers!(options)
+      json = client.list("/v1/auth/approle/role/#{CGI.escape(role_name)}/secret-id", options, headers)
+      return Secret.decode(json).data[:keys] || []
+    rescue HTTPError => e
+      return [] if e.code == 404
+      raise
+    end
+  end
+end

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -74,6 +74,30 @@ module Vault
       return secret
     end
 
+    # Authenticate via the "approle" authentication method. If authentication is
+    # successful, the resulting token will be stored on the client and used for
+    # future requests.
+    #
+    # @example
+    #   Vault.auth.approle(
+    #     "db02de05-fa39-4855-059b-67221c5c2f63",
+    #     "6a174c20-f6de-a53c-74d2-6018fcceff64",
+    #   ) #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] role_id
+    # @param [String] secret_id (default: nil)
+    #   It is required when `bind_secret_id` is enabled for the specified role_id
+    #
+    # @return [Secret]
+    def approle(role_id, secret_id=nil)
+      payload = { role_id: role_id }
+      payload[:secret_id] = secret_id if secret_id
+      json = client.post("/v1/auth/approle/login", JSON.fast_generate(payload))
+      secret = Secret.decode(json)
+      client.token = secret.auth.client_token
+      return secret
+    end
+
     # Authenticate via the "userpass" authentication method. If authentication
     # is successful, the resulting token will be stored on the client and used
     # for future requests.

--- a/spec/integration/api/approle_spec.rb
+++ b/spec/integration/api/approle_spec.rb
@@ -1,0 +1,152 @@
+require "spec_helper"
+
+module Vault
+  describe AppRole, vault: ">= 0.6.1" do
+    subject { vault_test_client.approle }
+
+    before(:context) do
+      vault_test_client.sys.enable_auth("approle", "approle", nil)
+      @approle  = "sample-role-name"
+    end
+
+    after(:context) do
+      vault_test_client.sys.disable_auth("approle")
+    end
+
+    let(:role) do
+      {
+        bind_secret_id:     true,
+        bound_cidr_list:    "",
+        secret_id_num_uses: 10,
+        secret_id_ttl:      3600,
+        policies:           "default",
+        period:             1800
+      }
+    end
+
+    let(:role_res) do
+      {
+        bind_secret_id:     true,
+        bound_cidr_list:    "",
+        secret_id_num_uses: 10,
+        secret_id_ttl:      3600,
+        token_max_ttl:      0,
+        token_ttl:          0,
+        policies:           ["default"],
+        period:             1800
+      }
+    end
+
+    before do
+      vault_test_client.approle.set_role(@approle)
+    end
+
+    after do
+      vault_test_client.approle.delete_role(@approle)
+    end
+
+    describe "#set_role" do
+      it "sets the AppRole" do
+        expect(subject.set_role(@approle, role)).to be(true)
+      end
+    end
+
+    describe "#role" do
+      it "reads the AppRole" do
+        subject.set_role(@approle, role)
+        result = subject.role(@approle)
+        expect(result).to be_a(Vault::Secret)
+        expect(result.data).to eq(role_res)
+      end
+
+      it "returns nil when the AppRole does not exist" do
+        result = subject.role("nope-nope-nope")
+        expect(result).to be(nil)
+      end
+    end
+
+    describe "#roles" do
+      it "lists all AppRoles by name" do
+        result = subject.roles
+        expect(result).to include(@approle)
+      end
+    end
+
+    describe "#role_id" do
+      it "reads the AppRole ID" do
+        result = subject.role_id(@approle)
+        expect(result).to be_a(String)
+      end
+
+      it "returns nil when the AppRole does not exist" do
+        result = subject.role_id("nope-nope-nope")
+        expect(result).to be(nil)
+      end
+    end
+
+    describe "#set_role_id" do
+      it "sets the AppRole ID" do
+        expect(subject.set_role_id(@approle, "testroleid")).to be(true)
+        expect(subject.role_id(@approle)).to eq("testroleid")
+      end
+    end
+
+    describe "#delete_role", vault: ">= 0.6.2" do
+      it "deletes the AppRole" do
+        expect(subject.delete_role(@approle)).to be(true)
+      end
+
+      it "does nothing if the AppRole does not exist" do
+        expect {
+          subject.delete_role("nope-nope-nope")
+        }.to_not raise_error
+      end
+    end
+
+    describe "#create_secret_id" do
+      it "generates the new SecretID" do
+        result = subject.create_secret_id(@approle)
+        expect(result).to be_a(Vault::Secret)
+        expect(result.data).to include(:secret_id)
+        expect(result.data).to include(:secret_id_accessor)
+        expect(result.data[:secret_id]).to be_a(String)
+        expect(result.data[:secret_id_accessor]).to be_a(String)
+      end
+
+      it "assigns the custom SecretID" do
+        opts = { secret_id: "testsecretid" }
+        result = subject.create_secret_id(@approle, opts)
+        expect(result).to be_a(Vault::Secret)
+        expect(result.data).to include(secret_id: "testsecretid")
+        expect(result.data).to include(:secret_id_accessor)
+        expect(result.data[:secret_id_accessor]).to be_a(String)
+      end
+    end
+
+    describe "#secret_id" do
+      it "reads the SecretID" do
+        opts = { secret_id: "testsecretid" }
+        subject.create_secret_id(@approle, opts)
+        result = subject.secret_id(@approle, "testsecretid")
+        expect(result).to be_a(Vault::Secret)
+        expect(result.data).to include(:secret_id_accessor)
+        expect(result.data).to include(:secret_id_num_uses)
+        expect(result.data).to include(:secret_id_ttl)
+      end
+
+      it "returns nil when the SecretId does not exist" do
+        result = subject.secret_id(@approle, "nope-nope-nope")
+        expect(result).to be(nil)
+      end
+    end
+
+    describe "#secret_id_accessors" do
+      it "lists all SecretID accessors" do
+        2.times { subject.create_secret_id(@approle) }
+        result = subject.secret_id_accessors(@approle)
+        expect(result).to be_an(Array)
+        expect(result.length).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`AppRole` auth backend is available in Vault >= 0.6.1: https://www.vaultproject.io/docs/auth/approle.html

Any notes and suggestions are welcome.

__Caveat:__
Calling `#delete_role` with non-existing role name causes a panic of Vault server. It was fixed by https://github.com/hashicorp/vault/pull/1920 and should work in the upcoming Vault version (>= 0.6.2).