### PR TITLE
Clarify that VERIFY_PEER is always used

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -194,6 +194,7 @@ module Vault
       if uri.scheme == "https"
         # Turn on SSL
         connection.use_ssl = true
+        connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
         # Vault requires TLS1.2
         connection.ssl_version = "TLSv1_2"
@@ -206,7 +207,6 @@ module Vault
         if pem
           connection.cert = OpenSSL::X509::Certificate.new(pem)
           connection.key = OpenSSL::PKey::RSA.new(pem, ssl_pem_passphrase)
-          connection.verify_mode = OpenSSL::SSL::VERIFY_PEER
         end
 
         # Use custom CA cert for verification


### PR DESCRIPTION
We were previously still doing VERIFY_PEER because it's the default
mode. This created confusion that using peer certs were required for
VERIFY_PEER to be used. This clarifies and makes sure that VERIFY_PEER
is used.