### PR TITLE
Encode URL paths properly. Fixes #95

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ env:
   - VAULT_VERSION=0.6.1
   - VAULT_VERSION=0.6.0
   - VAULT_VERSION=0.5.3
-  - VAULT_VERSION=0.4.1
-  - VAULT_VERSION=0.3.1
 
 before_install:
   - wget -O vault.zip -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip

--- a/lib/vault/api/approle.rb
+++ b/lib/vault/api/approle.rb
@@ -58,7 +58,7 @@ module Vault
     # @return [true]
     def set_role(name, options = {})
       headers = extract_headers!(options)
-      client.post("/v1/auth/approle/role/#{CGI.escape(name)}", JSON.fast_generate(options), headers)
+      client.post("/v1/auth/approle/role/#{encode_path(name)}", JSON.fast_generate(options), headers)
       return true
     end
 
@@ -70,7 +70,7 @@ module Vault
     #
     # @return [Secret, nil]
     def role(name)
-      json = client.get("/v1/auth/approle/role/#{CGI.escape(name)}")
+      json = client.get("/v1/auth/approle/role/#{encode_path(name)}")
       return Secret.decode(json)
     rescue HTTPError => e
       return nil if e.code == 404
@@ -100,7 +100,7 @@ module Vault
     #
     # @return [Secret, nil]
     def role_id(name)
-      json = client.get("/v1/auth/approle/role/#{CGI.escape(name)}/role-id")
+      json = client.get("/v1/auth/approle/role/#{encode_path(name)}/role-id")
       return Secret.decode(json).data[:role_id]
     rescue HTTPError => e
       return nil if e.code == 404
@@ -115,7 +115,7 @@ module Vault
     # @return [true]
     def set_role_id(name, role_id)
       options = { role_id: role_id }
-      client.post("/v1/auth/approle/role/#{CGI.escape(name)}/role-id", JSON.fast_generate(options))
+      client.post("/v1/auth/approle/role/#{encode_path(name)}/role-id", JSON.fast_generate(options))
       return true
     end
 
@@ -128,7 +128,7 @@ module Vault
     # @param [String] name
     #   the name of the certificate
     def delete_role(name)
-      client.delete("/v1/auth/approle/role/#{CGI.escape(name)}")
+      client.delete("/v1/auth/approle/role/#{encode_path(name)}")
       return true
     end
 
@@ -160,9 +160,9 @@ module Vault
     def create_secret_id(role_name, options = {})
       headers = extract_headers!(options)
       if options[:secret_id]
-        json = client.post("/v1/auth/approle/role/#{CGI.escape(role_name)}/custom-secret-id", JSON.fast_generate(options), headers)
+        json = client.post("/v1/auth/approle/role/#{encode_path(role_name)}/custom-secret-id", JSON.fast_generate(options), headers)
       else
-        json = client.post("/v1/auth/approle/role/#{CGI.escape(role_name)}/secret-id", JSON.fast_generate(options), headers)
+        json = client.post("/v1/auth/approle/role/#{encode_path(role_name)}/secret-id", JSON.fast_generate(options), headers)
       end
       return Secret.decode(json)
     end
@@ -181,13 +181,13 @@ module Vault
     # @return [Secret, nil]
     def secret_id(role_name, secret_id)
       opts = { secret_id: secret_id }
-      json = client.post("/v1/auth/approle/role/#{CGI.escape(role_name)}/secret-id/lookup", JSON.fast_generate(opts), {})
+      json = client.post("/v1/auth/approle/role/#{encode_path(role_name)}/secret-id/lookup", JSON.fast_generate(opts), {})
       return nil unless json
       return Secret.decode(json)
     rescue HTTPError => e
       if e.code == 404 || e.code == 405
         begin
-          json = client.get("/v1/auth/approle/role/#{CGI.escape(role_name)}/secret-id/#{CGI.escape(secret_id)}")
+          json = client.get("/v1/auth/approle/role/#{encode_path(role_name)}/secret-id/#{encode_path(secret_id)}")
           return Secret.decode(json)
         rescue HTTPError => e
           return nil if e.code == 404
@@ -208,7 +208,7 @@ module Vault
     # @return [Array<String>]
     def secret_id_accessors(role_name, options = {})
       headers = extract_headers!(options)
-      json = client.list("/v1/auth/approle/role/#{CGI.escape(role_name)}/secret-id", options, headers)
+      json = client.list("/v1/auth/approle/role/#{encode_path(role_name)}/secret-id", options, headers)
       return Secret.decode(json).data[:keys] || []
     rescue HTTPError => e
       return [] if e.code == 404

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -117,7 +117,7 @@ module Vault
     # @return [Secret]
     def userpass(username, password, options = {})
       payload = { password: password }.merge(options)
-      json = client.post("/v1/auth/userpass/login/#{CGI.escape(username)}", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/userpass/login/#{encode_path(username)}", JSON.fast_generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -139,7 +139,7 @@ module Vault
     # @return [Secret]
     def ldap(username, password, options = {})
       payload = { password: password }.merge(options)
-      json = client.post("/v1/auth/ldap/login/#{CGI.escape(username)}", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/ldap/login/#{encode_path(username)}", JSON.fast_generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret

--- a/lib/vault/api/auth_tls.rb
+++ b/lib/vault/api/auth_tls.rb
@@ -42,7 +42,7 @@ module Vault
     # @return [true]
     def set_certificate(name, options = {})
       headers = extract_headers!(options)
-      client.post("/v1/auth/cert/certs/#{CGI.escape(name)}", JSON.fast_generate(options), headers)
+      client.post("/v1/auth/cert/certs/#{encode_path(name)}", JSON.fast_generate(options), headers)
       return true
     end
 
@@ -54,7 +54,7 @@ module Vault
     #
     # @return [Secret, nil]
     def certificate(name)
-      json = client.get("/v1/auth/cert/certs/#{CGI.escape(name)}")
+      json = client.get("/v1/auth/cert/certs/#{encode_path(name)}")
       return Secret.decode(json)
     rescue HTTPError => e
       return nil if e.code == 404
@@ -85,7 +85,7 @@ module Vault
     # @param [String] name
     #   the name of the certificate
     def delete_certificate(name)
-      client.delete("/v1/auth/cert/certs/#{CGI.escape(name)}")
+      client.delete("/v1/auth/cert/certs/#{encode_path(name)}")
       return true
     end
   end

--- a/lib/vault/api/auth_token.rb
+++ b/lib/vault/api/auth_token.rb
@@ -95,7 +95,7 @@ module Vault
     # @return [Secret]
     def create_with_role(name, options = {})
       headers = extract_headers!(options)
-      json = client.post("/v1/auth/token/create/#{CGI.escape(name)}", JSON.fast_generate(options), headers)
+      json = client.post("/v1/auth/token/create/#{encode_path(name)}", JSON.fast_generate(options), headers)
       return Secret.decode(json)
     end
 
@@ -108,7 +108,7 @@ module Vault
     #
     # @return [Secret]
     def lookup(token)
-      json = client.get("/v1/auth/token/lookup/#{CGI.escape(token)}")
+      json = client.get("/v1/auth/token/lookup/#{encode_path(token)}")
       return Secret.decode(json)
     end
 

--- a/lib/vault/api/help.rb
+++ b/lib/vault/api/help.rb
@@ -26,7 +26,7 @@ module Vault
     #
     # @return [Help]
     def help(path)
-      json = self.get("/v1/#{CGI.escape(path)}", help: 1)
+      json = self.get("/v1/#{EncodePath.encode_path(path)}", help: 1)
       return Help.decode(json)
     end
   end

--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -25,7 +25,7 @@ module Vault
     # @return [Array<String>]
     def list(path, options = {})
       headers = extract_headers!(options)
-      json = client.list("/v1/#{CGI.escape(path)}", {}, headers)
+      json = client.list("/v1/#{encode_path(path)}", {}, headers)
       json[:data][:keys] || []
     rescue HTTPError => e
       return [] if e.code == 404
@@ -44,7 +44,7 @@ module Vault
     # @return [Secret, nil]
     def read(path, options = {})
       headers = extract_headers!(options)
-      json = client.get("/v1/#{CGI.escape(path)}", {}, headers)
+      json = client.get("/v1/#{encode_path(path)}", {}, headers)
       return Secret.decode(json)
     rescue HTTPError => e
       return nil if e.code == 404
@@ -65,7 +65,7 @@ module Vault
     # @return [Secret]
     def write(path, data = {}, options = {})
       headers = extract_headers!(options)
-      json = client.put("/v1/#{CGI.escape(path)}", JSON.fast_generate(data), headers)
+      json = client.put("/v1/#{encode_path(path)}", JSON.fast_generate(data), headers)
       if json.nil?
         return true
       else
@@ -84,7 +84,7 @@ module Vault
     #
     # @return [true]
     def delete(path)
-      client.delete("/v1/#{CGI.escape(path)}")
+      client.delete("/v1/#{encode_path(path)}")
       return true
     end
 

--- a/lib/vault/api/sys/audit.rb
+++ b/lib/vault/api/sys/audit.rb
@@ -51,7 +51,7 @@ module Vault
     #
     # @return [true]
     def enable_audit(path, type, description, options = {})
-      client.put("/v1/sys/audit/#{CGI.escape(path)}", JSON.fast_generate(
+      client.put("/v1/sys/audit/#{encode_path(path)}", JSON.fast_generate(
         type:        type,
         description: description,
         options:     options,
@@ -67,7 +67,7 @@ module Vault
     #
     # @return [true]
     def disable_audit(path)
-      client.delete("/v1/sys/audit/#{CGI.escape(path)}")
+      client.delete("/v1/sys/audit/#{encode_path(path)}")
       return true
     end
   end

--- a/lib/vault/api/sys/auth.rb
+++ b/lib/vault/api/sys/auth.rb
@@ -57,7 +57,7 @@ module Vault
       payload = { type: type }
       payload[:description] = description if !description.nil?
 
-      client.post("/v1/sys/auth/#{CGI.escape(path)}", JSON.fast_generate(payload))
+      client.post("/v1/sys/auth/#{encode_path(path)}", JSON.fast_generate(payload))
       return true
     end
 
@@ -72,7 +72,7 @@ module Vault
     #
     # @return [true]
     def disable_auth(path)
-      client.delete("/v1/sys/auth/#{CGI.escape(path)}")
+      client.delete("/v1/sys/auth/#{encode_path(path)}")
       return true
     end
 
@@ -87,7 +87,7 @@ module Vault
     # @return [AuthConfig]
     #   configuration of the given auth path
     def auth_tune(path)
-      json = client.get("/v1/sys/auth/#{CGI.escape(path)}/tune")
+      json = client.get("/v1/sys/auth/#{encode_path(path)}/tune")
       return AuthConfig.decode(json)
     rescue HTTPError => e
       return nil if e.code == 404
@@ -105,7 +105,7 @@ module Vault
     # @return [AuthConfig]
     #   configuration of the given auth path
     def put_auth_tune(path, config = {})
-      json = client.put("/v1/sys/auth/#{CGI.escape(path)}/tune", JSON.fast_generate(config))
+      json = client.put("/v1/sys/auth/#{encode_path(path)}/tune", JSON.fast_generate(config))
       if json.nil?
         return true
       else

--- a/lib/vault/api/sys/mount.rb
+++ b/lib/vault/api/sys/mount.rb
@@ -48,7 +48,7 @@ module Vault
       payload = { type: type }
       payload[:description] = description if !description.nil?
 
-      client.post("/v1/sys/mounts/#{CGI.escape(path)}", JSON.fast_generate(payload))
+      client.post("/v1/sys/mounts/#{encode_path(path)}", JSON.fast_generate(payload))
       return true
     end
 
@@ -62,7 +62,7 @@ module Vault
     # @param [Hash] data
     #   the data to write
     def mount_tune(path, data = {})
-      json = client.post("/v1/sys/mounts/#{CGI.escape(path)}/tune", JSON.fast_generate(data))
+      json = client.post("/v1/sys/mounts/#{encode_path(path)}/tune", JSON.fast_generate(data))
       return true
     end
 
@@ -77,7 +77,7 @@ module Vault
     #
     # @return [true]
     def unmount(path)
-      client.delete("/v1/sys/mounts/#{CGI.escape(path)}")
+      client.delete("/v1/sys/mounts/#{encode_path(path)}")
       return true
     end
 

--- a/lib/vault/api/sys/policy.rb
+++ b/lib/vault/api/sys/policy.rb
@@ -40,7 +40,7 @@ module Vault
     #
     # @return [Policy, nil]
     def policy(name)
-      json = client.get("/v1/sys/policy/#{CGI.escape(name)}")
+      json = client.get("/v1/sys/policy/#{encode_path(name)}")
       return Policy.decode(json)
     rescue HTTPError => e
       return nil if e.code == 404
@@ -70,7 +70,7 @@ module Vault
     #
     # @return [true]
     def put_policy(name, rules)
-      client.put("/v1/sys/policy/#{CGI.escape(name)}", JSON.fast_generate(
+      client.put("/v1/sys/policy/#{encode_path(name)}", JSON.fast_generate(
         rules: rules,
       ))
       return true
@@ -85,7 +85,7 @@ module Vault
     # @param [String] name
     #   the name of the policy
     def delete_policy(name)
-      client.delete("/v1/sys/policy/#{CGI.escape(name)}")
+      client.delete("/v1/sys/policy/#{encode_path(name)}")
       return true
     end
   end

--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -7,6 +7,7 @@ require_relative "vendor/net/http/persistent"
 require_relative "configurable"
 require_relative "errors"
 require_relative "version"
+require_relative "encode"
 
 module Vault
   class Client

--- a/lib/vault/encode.rb
+++ b/lib/vault/encode.rb
@@ -1,5 +1,13 @@
 module Vault
   module EncodePath
+
+    # Encodes a string according to the rules for URL paths. This is
+    # used as opposed to CGI.escape because in a URL path, space
+    # needs to be escaped as %20 and CGI.escapes a space as +.
+    #
+    # @param [String]
+    #
+    # @return [String]
     def encode_path(path)
       path.b.gsub(%r!([^a-zA-Z0-9_.-/]+)!) { |m|
         '%' + m.unpack('H2' * m.bytesize).join('%').upcase

--- a/lib/vault/encode.rb
+++ b/lib/vault/encode.rb
@@ -1,0 +1,11 @@
+module Vault
+  module EncodePath
+    def encode_path(path)
+      path.b.gsub(%r!([^a-zA-Z0-9_.-/]+)!) { |m|
+        '%' + m.unpack('H2' * m.bytesize).join('%').upcase
+      }
+    end
+
+    module_function :encode_path
+  end
+end

--- a/lib/vault/request.rb
+++ b/lib/vault/request.rb
@@ -18,6 +18,8 @@ module Vault
 
     private
 
+    include EncodePath
+
     # Removes the given header fields from options and returns the result. This
     # modifies the given options in place.
     #
@@ -37,7 +39,5 @@ module Vault
         end
       end
     end
-
-    include EncodePath
   end
 end

--- a/lib/vault/request.rb
+++ b/lib/vault/request.rb
@@ -37,5 +37,7 @@ module Vault
         end
       end
     end
+
+    include EncodePath
   end
 end

--- a/spec/integration/api/auth_tls_spec.rb
+++ b/spec/integration/api/auth_tls_spec.rb
@@ -21,7 +21,7 @@ module Vault
       }
     end
 
-    describe "#set_certificate", vault: ">= 0.5.3" do
+    describe "#set_certificate" do
       it "sets the certificate" do
         expect(subject.set_certificate("sample", certificate)).to be(true)
         result = subject.certificate("sample")
@@ -30,7 +30,7 @@ module Vault
       end
     end
 
-    describe "#certificate", vault: ">= 0.5.3" do
+    describe "#certificate" do
       it "gets the certificate" do
         subject.set_certificate("sample", certificate)
         result = subject.certificate("sample")
@@ -44,7 +44,7 @@ module Vault
       end
     end
 
-    describe "#certificates", vault: ">= 0.5.3" do
+    describe "#certificates" do
       it "lists all certificates by name" do
         subject.set_certificate("sample", certificate)
         result = subject.certificates

--- a/spec/integration/api/auth_token_spec.rb
+++ b/spec/integration/api/auth_token_spec.rb
@@ -29,7 +29,7 @@ module Vault
       end
     end
 
-    describe "#create_orphan", vault: ">= 0.4" do
+    describe "#create_orphan" do
       it "creates an orphaned token" do
         result = subject.auth_token.create_orphan
         expect(result).to be_a(Vault::Secret)
@@ -92,7 +92,7 @@ module Vault
       end
     end
 
-    describe "#renew_self", vault: ">= 0.4" do
+    describe "#renew_self" do
       it "renews the calling token" do
         token = subject.auth_token.create(policies: ["default"])
         subject.auth.token(token.auth.client_token)
@@ -102,7 +102,7 @@ module Vault
       end
     end
 
-    describe "#revoke_self", vault: ">= 0.4" do
+    describe "#revoke_self" do
       it "revokes the calling token" do
         token = subject.auth_token.create(policies: ["default"])
         subject.auth.token(token.auth.client_token)

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -4,7 +4,7 @@ module Vault
   describe Logical do
     subject { vault_test_client.logical }
 
-    describe "#list", vault: ">= 0.5" do
+    describe "#list" do
       it "returns the empty array when no items exist" do
         expect(subject.list("secret/that/never/existed")).to eq([])
       end

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -62,6 +62,15 @@ module Vault
         expect(secret).to be
         expect(secret.data).to eq(bacon: true)
       end
+
+      it "respects spaces properly" do
+        key = 'secret/sub/"Test Group"'
+        subject.write(key, foo: "bar")
+        expect(subject.list("secret/sub")).to eq(['"Test Group"'])
+        secret = subject.read(key)
+        expect(secret).to be
+        expect(secret.data).to eq(foo:"bar")
+      end
     end
 
     describe "#delete" do

--- a/spec/integration/api/sys/leader_spec.rb
+++ b/spec/integration/api/sys/leader_spec.rb
@@ -17,7 +17,7 @@ module Vault
       end
     end
 
-    describe "#step_down", vault: ">= 0.5.3" do
+    describe "#step_down" do
       it "steps down if leader" do
         result = subject.step_down
         expect(result).to be(true)


### PR DESCRIPTION
`CGI.escape` uses `+` to escape a ` `, which only valid when used in a query parameter, not in a path. Vault's path decoder treats the `+` as a literal `+`, not a ` `.

This change uses a modified version of `CGI.escape` that encodes ` ` as `%20`.