### PR TITLE
Expose pool_size configuration

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -83,7 +83,7 @@ module Vault
       @lock.synchronize do
         return @nhp if @nhp
 
-        @nhp = PersistentHTTP.new(name: "vault-ruby")
+        @nhp = PersistentHTTP.new("vault-ruby", nil, pool_size)
 
         if hostname
           @nhp.hostname = hostname

--- a/lib/vault/configurable.rb
+++ b/lib/vault/configurable.rb
@@ -12,6 +12,7 @@ module Vault
         :proxy_password,
         :proxy_port,
         :proxy_username,
+        :pool_size,
         :read_timeout,
         :ssl_ciphers,
         :ssl_pem_contents,

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -26,6 +26,9 @@ module Vault
     # The maximum amount of time for a single exponential backoff to sleep.
     RETRY_MAX_WAIT = 2.0
 
+    # The default size of the connection pool
+    DEFAULT_POOL_SIZE = 16
+
     class << self
       # The list of calculated options for this configurable.
       # @return [Hash]
@@ -64,6 +67,16 @@ module Vault
       # @return [String, nil]
       def open_timeout
         ENV["VAULT_OPEN_TIMEOUT"]
+      end
+
+      # The size of the connection pool to communicate with Vault
+      # @return Integer
+      def pool_size
+        if var = ENV["VAULT_POOL_SIZE"]
+          return var.to_i
+        else
+          DEFAULT_POOL_SIZE
+        end
       end
 
       # The HTTP Proxy server address as a string


### PR DESCRIPTION
This allows the connection pool that is used to talk to vault to be configured in size.