### PR TITLE
Time.parse requires time

### DIFF
--- a/lib/vault/api/secret.rb
+++ b/lib/vault/api/secret.rb
@@ -1,4 +1,5 @@
 require_relative "../response"
+require "time"
 
 module Vault
   # Secret is a representation of a secret from Vault. Almost all data returned

--- a/lib/vault/api/secret.rb
+++ b/lib/vault/api/secret.rb
@@ -1,5 +1,6 @@
-require_relative "../response"
 require "time"
+
+require_relative "../response"
 
 module Vault
   # Secret is a representation of a secret from Vault. Almost all data returned


### PR DESCRIPTION
At https://github.com/hashicorp/vault-ruby/blob/447fcb32f9a0331d6856753183219576010d5782/lib/vault/api/secret.rb#L147 , `Time.parse` is called, which necessitates a `require 'time'` ([per the ruby docs](https://ruby-doc.org/stdlib-2.4.0/libdoc/time/rdoc/Time.html)). It's part of stdlib, but you have to explicitly declare it.

You can work around it by doing a `require 'time'` in whatever pulls in the vault gem, but this really should happen in the gem itself.