### PR TITLE
Setup a default set of exceptions to retry

### DIFF
--- a/lib/vault.rb
+++ b/lib/vault.rb
@@ -1,8 +1,8 @@
 module Vault
+  require_relative "vault/errors"
   require_relative "vault/client"
   require_relative "vault/configurable"
   require_relative "vault/defaults"
-  require_relative "vault/errors"
   require_relative "vault/response"
   require_relative "vault/version"
 

--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -409,6 +409,8 @@ module Vault
       exception    = nil
       retries      = 0
 
+      rescued = Defaults::RETRIED_EXCEPTIONS if rescued.empty?
+
       max_attempts = options[:attempts] || Defaults::RETRY_ATTEMPTS
       backoff_base = options[:base]     || Defaults::RETRY_BASE
       backoff_max  = options[:max_wait] || Defaults::RETRY_MAX_WAIT

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -29,6 +29,10 @@ module Vault
     # The default size of the connection pool
     DEFAULT_POOL_SIZE = 16
 
+    # The set of exceptions that are detect and retried by default
+    # with `with_retries`
+    RETRIED_EXCEPTIONS = [HTTPServerError]
+
     class << self
       # The list of calculated options for this configurable.
       # @return [Hash]

--- a/spec/unit/client_spec.rb
+++ b/spec/unit/client_spec.rb
@@ -154,6 +154,16 @@ module Vault
             end
           }.to raise_error(Vault::HTTPServerError)
         end
+
+        it "is detected by default on #{code}" do
+          stub_request(:get, "https://vault.test/")
+            .to_return(status: code, body: "#{code}")
+          expect {
+            subject.with_retries(options) do
+              subject.get("/")
+            end
+          }.to raise_error(Vault::HTTPServerError)
+        end
       end
     end
   end


### PR DESCRIPTION
At present, if `with_retries` is used, no errors are detected because the code `rescue *exc` where `exc` is empty doesn't rescue anything (not even the default `RuntimeError`).

Code such as `vault-rails` uses `with_retries`, so it seems sensible that `with_retries` should have a default set to retry.

This defines that set to be any error returned by Vault itself. This should solve certain errors that come along with Vault leader elections causing 500s to be returned.