### PR TITLE
fixes revoke-accessor API path

### DIFF
--- a/lib/vault/api/auth_token.rb
+++ b/lib/vault/api/auth_token.rb
@@ -215,7 +215,7 @@ module Vault
     # @return [true]
     def revoke_accessor(accessor, options = {})
       headers = extract_headers!(options)
-      client.put("/v1/auth/accessor/revoke-accessor", JSON.fast_generate(
+      client.put("/v1/auth/token/revoke-accessor", JSON.fast_generate(
         accessor: accessor,
       ), headers)
       return true


### PR DESCRIPTION
Getting
```
  * no handler for route 'auth/accessor/revoke-accessor//'
```
Cannot find in the vault changelog when it changed so maybe it never actually worked?