### PR TITLE
Add custom mount path support to Authentication#tls

### DIFF
--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -194,15 +194,21 @@ module Vault
     # @example Reading a pem from disk
     #   Vault.auth.tls(File.read("/path/to/my/certificate.pem")) #=> #<Vault::Secret lease_id="">
     #
+    # @example Sending to a cert authentication backend mounted at a custom location
+    #   Vault.auth.tls(pem_contents, 'custom/location') #=> #<Vault::Secret lease_id="">
+    #
     # @param [String] pem (default: the configured SSL pem file or contents)
     #   The raw pem contents to use for the login procedure.
     #
+    # @param [String] path (default: 'cert')
+    #   The path to the auth backend to use for the login procedure.
+    #
     # @return [Secret]
-    def tls(pem = nil)
+    def tls(pem = nil, path = 'cert')
       new_client = client.dup
       new_client.ssl_pem_contents = pem if !pem.nil?
 
-      json = new_client.post("/v1/auth/cert/login")
+      json = new_client.post("/v1/auth/#{path}/login")
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -208,7 +208,7 @@ module Vault
       new_client = client.dup
       new_client.ssl_pem_contents = pem if !pem.nil?
 
-      json = new_client.post("/v1/auth/#{path}/login")
+      json = new_client.post("/v1/auth/#{CGI.escape(path)}/login")
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret


### PR DESCRIPTION
Hi Hashicorp folks!

I'm working on a project that requires several custom cert authentication backends, and I'd really like to use this gem to auth with them. This PR adds a `path` parameter to Authentication#tls to support cert backends mounted at non-default locations.

`rake spec` results: 
Finished in 2.93 seconds (files took 0.58295 seconds to load)
215 examples, 0 failures, 6 pending
