### PR TITLE
Vault.auth_token.lookup typo

### DIFF
--- a/lib/vault/api/auth_token.rb
+++ b/lib/vault/api/auth_token.rb
@@ -102,7 +102,7 @@ module Vault
     # Lookup information about the current token.
     #
     # @example
-    #   Vault.auth_token.lookup_self("abcd-...") #=> #<Vault::Secret lease_id="">
+    #   Vault.auth_token.lookup("abcd-...") #=> #<Vault::Secret lease_id="">
     #
     # @param [String] token
     # @param [Hash] options


### PR DESCRIPTION
In comments (docs) there is a typo, example for `Vault.auth_token.lookup` use `Vault.auth_token.lookup_self`.