### PR TITLE
Allow PEM contents as Base64 encoded string

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Vault.configure do |config|
   # Custom SSL PEM, also read as ENV["VAULT_SSL_CERT"]
   config.ssl_pem_file = "/path/on/disk.pem"
 
+  # As an alternative to a pem file, you can provide the raw PEM string, also read in the following order of preference:
+  # ENV["VAULT_SSL_PEM_CONTENTS_BASE64"] then ENV["VAULT_SSL_PEM_CONTENTS"]
+  config.ssl_pem_contents = "-----BEGIN ENCRYPTED..."
+
   # Use SSL verification, also read as ENV["VAULT_SSL_VERIFY"]
   config.ssl_verify = false
 

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -1,4 +1,5 @@
 require "pathname"
+require "base64"
 
 module Vault
   module Defaults
@@ -121,12 +122,16 @@ module Vault
         ENV["VAULT_SSL_CIPHERS"] || SSL_CIPHERS
       end
 
-      # The raw contents (as a string) for the pem file. To specify the path to
-      # the pem file, use {#ssl_pem_file} instead. This value is preferred over
-      # the value for {#ssl_pem_file}, if set.
+      # The raw contents (as a string) for the pem file, Base64-encoded or unencoded.
+      # To specify the path to the pem file, use {#ssl_pem_file} instead.
+      # This value is preferred over the value for {#ssl_pem_file}, if set.
       # @return [String, nil]
       def ssl_pem_contents
-        ENV["VAULT_SSL_PEM_CONTENTS"]
+        if ENV["VAULT_SSL_PEM_CONTENTS_BASE64"]
+          Base64.decode64(ENV["VAULT_SSL_PEM_CONTENTS_BASE64"])
+        else
+          ENV["VAULT_SSL_PEM_CONTENTS"]
+        end
       end
 
       # The path to a pem on disk to use with custom SSL verification

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -122,9 +122,9 @@ module Vault
         ENV["VAULT_SSL_CIPHERS"] || SSL_CIPHERS
       end
 
-      # The raw contents (as a string) for the pem file, Base64-encoded or unencoded.
-      # To specify the path to the pem file, use {#ssl_pem_file} instead.
-      # This value is preferred over the value for {#ssl_pem_file}, if set.
+      # The raw contents (as a string) for the pem file. To specify the path to
+      # the pem file, use {#ssl_pem_file} instead. This value is preferred over
+      # the value for {#ssl_pem_file}, if set.
       # @return [String, nil]
       def ssl_pem_contents
         if ENV["VAULT_SSL_PEM_CONTENTS_BASE64"]

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -128,9 +128,22 @@ module Vault
     end
 
     describe ".ssl_pem_contents" do
-      it "defaults to ENV['VAULT_SSL_PEM_CONTENTS']" do
+      it "defaults to ENV['VAULT_SSL_PEM_CONTENTS_BASE64']" do
+        with_stubbed_env("VAULT_SSL_PEM_CONTENTS_BASE64" => "YWJjZC0xMjM0\n") do
+          expect(Defaults.ssl_pem_contents).to eq("abcd-1234")
+        end
+      end
+
+      it "falls back to ENV['VAULT_SSL_PEM_CONTENTS']" do
         with_stubbed_env("VAULT_SSL_PEM_CONTENTS" => "abcd-1234") do
           expect(Defaults.ssl_pem_contents).to eq("abcd-1234")
+        end
+      end
+
+      it "returns nil if neither ENV['VAULT_SSL_PEM_CONTENTS'] \
+          nor ENV['VAULT_SSL_PEM_CONTENTS_BASE64'] are present" do
+        with_stubbed_env("VAULT_SSL_PEM_CONTENTS" => nil, "VAULT_SSL_PEM_CONTENTS_BASE64" => nil) do
+          expect(Defaults.ssl_pem_contents).to eq(nil)
         end
       end
     end


### PR DESCRIPTION
It is not possible to forward ENV vars with newlines in Docker, thus making it difficult to use `ssl_pem_contents` with Docker. Issue described further here: https://github.com/docker/compose/issues/3527

I realize these can be overridden in initializers/Client config, so would understand if you don't want to directly support this use case and rather allow folks to override it themselves. Will add specs if you give 👍  to implementation.