### PR TITLE
Add IAM EC2 auth

### DIFF
--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -191,7 +191,7 @@ module Vault
     # for future requests.
     #
     # @example
-    #   Vault.auth.aws_ecs_iam("dev-role-iam", Aws::AssumeRoleCredentials.new, "vault.example.com", "https://sts.us-east-2.amazonaws.com") #=> #<Vault::Secret lease_id="">
+    #   Vault.auth.aws_iam("dev-role-iam", Aws::AssumeRoleCredentials.new, "vault.example.com", "https://sts.us-east-2.amazonaws.com") #=> #<Vault::Secret lease_id="">
     #
     # @param [String] role
     # @param [CredentialProvider] credentials_provider

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -186,7 +186,7 @@ module Vault
       return secret
     end
 
-    # Authenticate via IAM EC2 method by providing a AWS CredentialProvider (either ECS, AssumeRole, etc.)
+    # Authenticate via AWS IAM auth method by providing a AWS CredentialProvider (either ECS, AssumeRole, etc.)
     # If authentication is successful, the resulting token will be stored on the client and used
     # for future requests.
     #
@@ -277,7 +277,7 @@ module Vault
     # Take care changing below regex with that edge case in mind
     #
     # @param [String] sts_endpoint
-    #   The raw pem contents to use for the login procedure.
+    #   https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
     #
     # @return [String] aws region
     def region_from_sts_endpoint(sts_endpoint)

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -197,7 +197,7 @@ module Vault
     # @param [CredentialProvider] credentials_provider
     #   https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/CredentialProvider.html
     # @param [String] iam_auth_header_value optional
-    #   As of Jan 2018, Vault will accept ANY or NO header, but this is subject to change and should not be relied upon
+    #   As of Jan 2018, Vault will accept ANY or NO header if none is configured by the Vault server admin
     # @param [String] sts_endpoint optional
     #   https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
     # @return [Secret]

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -205,6 +205,8 @@ module Vault
       require "aws-sigv4"
       require "base64"
 
+      # STS in the China (Beijing) region (cn-north-1) is sts.cn-north-1.amazonaws.com.cn
+      # Take care changing below regex with that edge case in mind
       valid_sts_endpoint = %r{https:\/\/sts.?(.*).amazonaws.com}.match(sts_endpoint)
       raise "Unable to parse STS endpoint #{sts_url}" unless valid_sts_endpoint
       region = valid_sts_endpoint[1].empty? ? 'us-east-1' : valid_sts_endpoint[1]

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -215,7 +215,7 @@ module Vault
       vault_headers = {
         'User-Agent' => Vault::Client::USER_AGENT,
         'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
-        'X-Vault-AWSIAM-Server-Id' => iam_auth_header_value
+        'X-Vault-AWS-IAM-Server-ID' => iam_auth_header_value
       }
 
       sig4_headers = Aws::Sigv4::Signer.new(

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -207,7 +207,7 @@ module Vault
 
       # STS in the China (Beijing) region (cn-north-1) is sts.cn-north-1.amazonaws.com.cn
       # Take care changing below regex with that edge case in mind
-      valid_sts_endpoint = %r{https:\/\/sts.?(.*).amazonaws.com}.match(sts_endpoint)
+      valid_sts_endpoint = %r{https:\/\/sts\.?(.*).amazonaws.com}.match(sts_endpoint)
       raise "Unable to parse STS endpoint #{sts_endpoint}" unless valid_sts_endpoint
       region = valid_sts_endpoint[1].empty? ? 'us-east-1' : valid_sts_endpoint[1]
 

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -208,7 +208,7 @@ module Vault
       # STS in the China (Beijing) region (cn-north-1) is sts.cn-north-1.amazonaws.com.cn
       # Take care changing below regex with that edge case in mind
       valid_sts_endpoint = %r{https:\/\/sts.?(.*).amazonaws.com}.match(sts_endpoint)
-      raise "Unable to parse STS endpoint #{sts_url}" unless valid_sts_endpoint
+      raise "Unable to parse STS endpoint #{sts_endpoint}" unless valid_sts_endpoint
       region = valid_sts_endpoint[1].empty? ? 'us-east-1' : valid_sts_endpoint[1]
 
       request_body   = 'Action=GetCallerIdentity&Version=2011-06-15'
@@ -235,7 +235,7 @@ module Vault
       payload = {
         role: role,
         iam_http_request_method: request_method,
-        iam_request_url: Base64.strict_encode64(sts_url),
+        iam_request_url: Base64.strict_encode64(sts_endpoint),
         iam_request_headers: Base64.strict_encode64(vault_headers.merge(sig4_headers).to_json),
         iam_request_body: Base64.strict_encode64(request_body)
       }

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -1,5 +1,3 @@
-require "aws-sigv4"
-require "base64"
 require "json"
 
 require_relative "secret"
@@ -192,8 +190,9 @@ module Vault
       return secret
     end
 
-    # Authenticate via the AWS EC2 authentication method (IAM method). If authentication is
-    # successful, the resulting token will be stored on the client and used
+    # Authenticate via the AWS EC2 authentication method (IAM method). Credentials & region are retrieved via
+    # the AWS Instnace Metadata API. 
+    # If authentication is successful, the resulting token will be stored on the client and used
     # for future requests.
     #
     # @example
@@ -205,52 +204,47 @@ module Vault
     # @return [Secret]
     def aws_ec2_iam(role, iam_auth_header_value = IAM_SERVER_ID_HEADER)
       aws_meta_data_host = 'http://169.254.169.254'
-      document_uri = URI.join(aws_meta_data_host, '/latest/dynamic/instance-identity/document')
-      document_api_response = Net::HTTP.get(document_uri)
-      document = JSON.parse(document_api_response)
+
+      document_uri  = URI.join(aws_meta_data_host, '/latest/dynamic/instance-identity/document')
+      document_json = Net::HTTP.get(document_uri)
+      document      = JSON.parse(document_json)
+      region        = document['region']
 
       role_base_uri = URI.join(aws_meta_data_host, '/latest/meta-data/iam/security-credentials/')
       aws_role_name = Net::HTTP.get(role_base_uri)
 
       credentials_uri = URI.join(aws_meta_data_host, role_base_uri, aws_role_name)
-      credentials_api_response = Net::HTTP.get(credentials_uri)
-      credentials = JSON.parse(credentials_api_response)
 
-      request_body = 'Action=GetCallerIdentity&Version=2011-06-15'
-      request_url = 'https://sts.amazonaws.com/'
-      request_method = 'POST'
+      return aws_iam(role, region, credentials_uri, iam_auth_header_value)
+    end
 
-      vault_headers = {
-        'User-Agent' => Vault::Client::USER_AGENT,
-        'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
-        'X-Vault-AWSIAM-Server-Id' => iam_auth_header_value
-      }
+    # Authenticate via the AWS ECS authentication method (IAM method). Credentials & region are retrieved via
+    # the ECS_CONTAINER_METADATA_FILE and AWS_CONTAINER_CREDENTIALS API.
+    # If authentication is successful, the resulting token will be stored on the client and used
+    # for future requests.
+    #
+    # @example
+    #   Vault.auth.aws_ecs_iam("dev-role-iam", "vault.example.com") #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] role
+    # @param [String] iam_auth_header_value optional
+    #
+    # @return [Secret]
+    def aws_ecs_iam(role, iam_auth_header_value = IAM_SERVER_ID_HEADER)
+      unless ENV['ECS_CONTAINER_METADATA_FILE']
+        raise 'missing env ECS_CONTAINER_METADATA_FILE. You may need to enable it by setting ECS_ENABLE_CONTAINER_METADATA' 
+      end
+      unless ENV['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI']
+        raise "missing env AWS_CONTAINER_CREDENTIALS_RELATIVE_URI. Are you sure you're running this withing an ECS task?" 
+      end
 
-      sig4_headers = Aws::Sigv4::Signer.new(
-        service: 'sts',
-        region: document['region'],
-        access_key_id: credentials['AccessKeyId'],
-        secret_access_key: credentials['SecretAccessKey'],
-        session_token: credentials['Token']
-      ).sign_request(
-        http_method: request_method,
-        url: request_url,
-        headers: vault_headers,
-        body: request_body
-      ).headers
+      document_json = File.read(ENV['ECS_CONTAINER_METADATA_FILE'])
+      document      = JSON.parse(document_json)
+      region        = document['ContainerInstanceARN'].split(':')[3]
 
-      payload = {
-        role: role,
-        iam_http_request_method: request_method,
-        iam_request_url: Base64.strict_encode64(request_url),
-        iam_request_headers: Base64.strict_encode64(vault_headers.merge(sig4_headers).to_json),
-        iam_request_body: Base64.strict_encode64(request_body)
-      }
+      credentials_uri = URI("http://169.254.170.2#{ENV['AWS_CONTAINER_CREDENTIALS_RELATIVE_URI']}")
 
-      json = client.post('/v1/auth/aws/login', JSON.fast_generate(payload))
-      secret = Secret.decode(json)
-      client.token = secret.auth.client_token
-      return secret
+      return aws_iam(role, region, credentials_uri, iam_auth_header_value)
     end
 
     # Authenticate via a TLS authentication method. If authentication is
@@ -278,6 +272,52 @@ module Vault
       new_client.ssl_pem_contents = pem if !pem.nil?
 
       json = new_client.post("/v1/auth/#{CGI.escape(path)}/login")
+      secret = Secret.decode(json)
+      client.token = secret.auth.client_token
+      return secret
+    end
+
+    private
+
+    def aws_iam(role, region, credentials_uri, iam_auth_header_value)
+      require "aws-sigv4"
+      require "base64"
+
+      credentials_api_response = Net::HTTP.get(credentials_uri)
+      credentials = JSON.parse(credentials_api_response)
+
+      request_body   = 'Action=GetCallerIdentity&Version=2011-06-15'
+      request_url    = 'https://sts.amazonaws.com/'
+      request_method = 'POST'
+
+      vault_headers = {
+        'User-Agent' => Vault::Client::USER_AGENT,
+        'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8',
+        'X-Vault-AWSIAM-Server-Id' => iam_auth_header_value
+      }
+
+      sig4_headers = Aws::Sigv4::Signer.new(
+        service: 'sts',
+        region: region,
+        access_key_id: credentials['AccessKeyId'],
+        secret_access_key: credentials['SecretAccessKey'],
+        session_token: credentials['Token']
+      ).sign_request(
+        http_method: request_method,
+        url: request_url,
+        headers: vault_headers,
+        body: request_body
+      ).headers
+
+      payload = {
+        role: role,
+        iam_http_request_method: request_method,
+        iam_request_url: Base64.strict_encode64(request_url),
+        iam_request_headers: Base64.strict_encode64(vault_headers.merge(sig4_headers).to_json),
+        iam_request_body: Base64.strict_encode64(request_body)
+      }
+
+      json = client.post('/v1/auth/aws/login', JSON.fast_generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -228,10 +228,11 @@ module Vault
       }
 
       sig4_headers = Aws::Sigv4::Signer.new(
-        service: 'iam',
+        service: 'sts',
         region: document['region'],
         access_key_id: credentials['AccessKeyId'],
-        secret_access_key: credentials['SecretAccessKey']
+        secret_access_key: credentials['SecretAccessKey'],
+        session_token: credentials['Token']
       ).sign_request(
         http_method: request_method,
         url: request_url,

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -191,17 +191,17 @@ module Vault
     # for future requests.
     #
     # @example
-    #   Vault.auth.aws_ecs_iam("dev-role-iam", Aws::AssumeRoleCredentials.new, "https://sts.us-east-2.amazonaws.com", "vault.example.com") #=> #<Vault::Secret lease_id="">
+    #   Vault.auth.aws_ecs_iam("dev-role-iam", Aws::AssumeRoleCredentials.new, "vault.example.com", "https://sts.us-east-2.amazonaws.com") #=> #<Vault::Secret lease_id="">
     #
     # @param [String] role
     # @param [CredentialProvider] credentials_provider
     #   https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/CredentialProvider.html
-    # @param [String] sts_endpoint optional
-    #   https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
     # @param [String] iam_auth_header_value optional
     #   As of Jan 2018, Vault will accept ANY or NO header, but this is subject to change and should not be relied upon
+    # @param [String] sts_endpoint optional
+    #   https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
     # @return [Secret]
-    def aws_iam(role, credentials_provider, sts_endpoint = 'https://sts.amazonaws.com', iam_auth_header_value = nil)
+    def aws_iam(role, credentials_provider, iam_auth_header_value = nil, sts_endpoint = 'https://sts.amazonaws.com')
       require "aws-sigv4"
       require "base64"
 

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -272,9 +272,15 @@ module Vault
 
     private
 
+    # Parse an AWS region from a STS endpoint
+    # STS in the China (Beijing) region (cn-north-1) is sts.cn-north-1.amazonaws.com.cn
+    # Take care changing below regex with that edge case in mind
+    #
+    # @param [String] sts_endpoint
+    #   The raw pem contents to use for the login procedure.
+    #
+    # @return [String] aws region
     def region_from_sts_endpoint(sts_endpoint)
-      # STS in the China (Beijing) region (cn-north-1) is sts.cn-north-1.amazonaws.com.cn
-      # Take care changing below regex with that edge case in mind
       valid_sts_endpoint = %r{https:\/\/sts\.?(.*).amazonaws.com}.match(sts_endpoint)
       raise "Unable to parse STS endpoint #{sts_endpoint}" unless valid_sts_endpoint
       valid_sts_endpoint[1].empty? ? 'us-east-1' : valid_sts_endpoint[1]

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -200,10 +200,10 @@ module Vault
     #   Vault.auth.aws_ec2_iam("dev-role-iam", "vault.example.com") #=> #<Vault::Secret lease_id="">
     #
     # @param [String] role
-    # @param [String] iam_auth_header_vaule
+    # @param [String] iam_auth_header_value optional
     #
     # @return [Secret]
-    def aws_ec2_iam(role, iam_auth_header_value)
+    def aws_ec2_iam(role, iam_auth_header_value = IAM_SERVER_ID_HEADER)
       aws_meta_data_host = 'http://169.254.169.254'
       document_uri = URI.join(aws_meta_data_host, '/latest/dynamic/instance-identity/document')
       document_api_response = Net::HTTP.get(document_uri)
@@ -219,7 +219,6 @@ module Vault
       request_body = 'Action=GetCallerIdentity&Version=2011-06-15'
       request_url = 'https://sts.amazonaws.com/'
       request_method = 'POST'
-      iam_auth_header_value ||= IAM_SERVER_ID_HEADER
 
       vault_headers = {
         'User-Agent' => Vault::Client::USER_AGENT,

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -216,6 +216,7 @@ module Vault
     describe "#aws_iam" do
       before(:context) do
         vault_test_client.sys.enable_auth("aws", "aws", nil)
+        vault_test_client.sys.put_auth_tune("aws", "iam_server_id_header_value" => "iam_header_canary")
       end
 
       after(:context) do
@@ -243,7 +244,7 @@ module Vault
             service: 'sts', region: 'cn-north-1', credentials_provider: credentials_provider
           ).and_call_original
         )
-        subject.auth.aws_iam('yabba', credentials_provider, 'canary_header', 'https://sts.cn-north-1.amazonaws.com.cn')
+        subject.auth.aws_iam('yabba', credentials_provider, 'iam_header_canary', 'https://sts.cn-north-1.amazonaws.com.cn')
       end
     end
   end

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "aws-sigv4"
 
 module Vault
   describe Auth do
@@ -209,6 +210,40 @@ module Vault
             subject.auth.tls(auth_cert)
           }.to raise_error(HTTPError)
         }.to_not change { subject.token }
+      end
+    end
+
+    describe "#aws_iam" do
+      before(:context) do
+        vault_test_client.sys.enable_auth("aws", "aws", nil)
+      end
+
+      after(:context) do
+        vault_test_client.sys.disable_auth("aws")
+      end
+
+      let!(:old_token) { subject.token }
+      let(:credentials_provider) do
+        double(
+          credentials:
+            double(access_key_id: 'very', secret_access_key: 'secure', session_token: 'thing')
+        )
+      end
+      let(:secret) { double(auth: double(client_token: 'a great token')) }
+
+      after do
+        subject.token = old_token
+      end
+
+      it "authenticates and saves the token on the client", vault: "> 0.7.3" do
+        expect(subject).to receive(:post).and_return 'huzzah!'
+        expect(Secret).to receive(:decode).and_return secret
+        expect(::Aws::Sigv4::Signer).to(
+          receive(:new).with(
+            service: 'sts', region: 'cn-north-1', credentials_provider: credentials_provider
+          ).and_call_original
+        )
+        subject.auth.aws_iam('yabba', credentials_provider, 'canary_header', 'https://sts.cn-north-1.amazonaws.com.cn')
       end
     end
   end

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -213,10 +213,10 @@ module Vault
       end
     end
 
-    describe "#aws_iam" do
+    describe "#aws_iam", vault: "> 0.7.3" do
       before(:context) do
         vault_test_client.sys.enable_auth("aws", "aws", nil)
-        vault_test_client.sys.put_auth_tune("aws", "iam_server_id_header_value" => "iam_header_canary")
+        vault_test_client.post("/v1/auth/aws/config/client", JSON.fast_generate("iam_server_id_header_value" => "iam_header_canary"))
       end
 
       after(:context) do
@@ -236,7 +236,18 @@ module Vault
         subject.token = old_token
       end
 
-      it "authenticates and saves the token on the client", vault: "> 0.7.3" do
+      it "does not authenticate if iam_server_id_header_value does not match" do
+        expect(::Aws::Sigv4::Signer).to(
+          receive(:new).with(
+            service: 'sts', region: 'cn-north-1', credentials_provider: credentials_provider
+          ).and_call_original
+        )
+        expect do
+          subject.auth.aws_iam('a_rolename', credentials_provider, 'mismatched_iam_header', 'https://sts.cn-north-1.amazonaws.com.cn') 
+        end.to raise_error(Vault::HTTPClientError, /expected iam_header_canary but got mismatched_iam_header/)
+      end
+
+      it "authenticates and saves the token on the client" do
         expect(subject).to receive(:post).and_return 'huzzah!'
         expect(Secret).to receive(:decode).and_return secret
         expect(::Aws::Sigv4::Signer).to(
@@ -244,7 +255,7 @@ module Vault
             service: 'sts', region: 'cn-north-1', credentials_provider: credentials_provider
           ).and_call_original
         )
-        subject.auth.aws_iam('yabba', credentials_provider, 'iam_header_canary', 'https://sts.cn-north-1.amazonaws.com.cn')
+        subject.auth.aws_iam('a_rolename', credentials_provider, 'iam_header_canary', 'https://sts.cn-north-1.amazonaws.com.cn')
       end
     end
   end

--- a/spec/unit/auth_spec.rb
+++ b/spec/unit/auth_spec.rb
@@ -1,0 +1,30 @@
+require "spec_helper"
+
+module Vault
+  describe Authenticate do
+    let(:auth) { Authenticate.new(client: nil) }
+    describe "#region_from_sts_endpoint" do
+      subject { auth.send(:region_from_sts_endpoint, sts_endpoint) }
+
+      context 'with a china endpoint' do
+        let(:sts_endpoint) { "https://sts.cn-north-1.amazonaws.com.cn" }
+        it { is_expected.to eq 'cn-north-1' }
+      end
+
+      context 'with a GovCloud endpoint' do
+        let(:sts_endpoint) { "https://sts.us-gov-west-1.amazonaws.com" }
+        it { is_expected.to eq 'us-gov-west-1' }
+      end
+
+      context 'with no regional endpoint' do
+        let(:sts_endpoint) { "https://sts.amazonaws.com" }
+        it { is_expected.to eq 'us-east-1' }
+      end
+
+      context 'with a malformed url' do
+        let(:sts_endpoint) { "https:sts.amazonaws.com" }
+        it { expect { subject }.to raise_exception(StandardError, "Unable to parse STS endpoint https:sts.amazonaws.com") }
+      end
+    end
+  end
+end

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "aws-sigv4"
+
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake",    "~> 12.0"


### PR DESCRIPTION
I melded the [gist](https://gist.github.com/tristanmorgan/8fe883f89db4537ce35e0a23f6a537b6) that @tristanmorgan posted and #144. I also used this python [snippet](http://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html) on the AWS documentation.

This uses the lightweight `aws-sigv4` gem as suggested by @evanphx. The gist above had a method for achieving it completely without a gem but I noticed the gist had (what appeared to me to be) some errors:

1. It wasn't signing all the headers
2. It wasn't signing the body of the request:

   ```ruby
   k_date    = OpenSSL::HMAC.digest('sha256', 'AWS4' + credentials['SecretAccessKey'], date_stamp)
   k_region  = OpenSSL::HMAC.digest('sha256', k_date, region_name)
   k_service = OpenSSL::HMAC.digest('sha256', k_region, 'iam')
   k_signing = OpenSSL::HMAC.digest('sha256', k_service, 'aws4_request')

   ...

   "SignedHeaders=content-length;content-type;host;x-amz-date;x-vault-server, Signature=#{k_signing}"
   ```

   whereas the ruby AWS SDK [does](https://github.com/aws/aws-sdk-ruby/blob/master/gems/aws-sigv4/lib/aws-sigv4/signer.rb#L396) and so does the python snippet:

   ```python
    # Step 7: Combine elements to create create canonical request
    canonical_request = method + '\n' + canonical_uri + '\n' + canonical_querystring + '\n' + canonical_headers + '\n' + signed_headers + '\n' + payload_hash

    algorithm = 'AWS4-HMAC-SHA256'
    credential_scope = datestamp + '/' + region + '/' + service + '/' + 'aws4_request'
    string_to_sign = algorithm + '\n' +  amzdate + '\n' +  credential_scope + '\n' +  hashlib.sha256(canonical_request).hexdigest()
   ```

The basic outline for what I did is this:

1. Use the Instance Metadata API to retrieve the AWS secret key, access key, and region
2. Create an IAM signer for the STS endpoint
3. Sign request with the Vault headers and body included
4. Merge the Sigv4 headers generated by the gem with the Vault headers to create the payload for the Vault API

@evanphx There are a couple open questions on our side that I think you'd be in a good position to answer:

1. Does the Vault role **name** necessarily need to be the same as the AWS role **name**?
2. ~What headers are necessary in `vault_headers`? Do we need things like `content-length`?~ In our testing it worked without it

#### TODO:

* [ ] Tests (I don't see any testing for other auth methods so unsure how to proceed on that)
* [ ] This is a fat method so I'm unsure if you'd like to split it up somehow
