### PR TITLE
update TLS Auth test for Vault 0.8.3 policy change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: ruby
 cache: bundler
 
 env:
+  - VAULT_VERSION=0.8.3
   - VAULT_VERSION=0.7.3
   - VAULT_VERSION=0.6.5
   - VAULT_VERSION=0.5.3

--- a/spec/integration/api/auth_tls_spec.rb
+++ b/spec/integration/api/auth_tls_spec.rb
@@ -26,7 +26,10 @@ module Vault
         expect(subject.set_certificate("sample", certificate)).to be(true)
         result = subject.certificate("sample")
         expect(result).to be_a(Vault::Secret)
-        expect(result.data).to eq(certificate)
+        expect(result.data[:display_name]).to eq(certificate[:display_name])
+        expect(result.data[:certificate]).to eq(certificate[:certificate])
+        expect(result.data[:ttl]).to eq(certificate[:ttl])
+        expect(result.data[:policies]).to eq(certificate[:policies]).or eq([certificate[:policies]])
       end
     end
 
@@ -35,7 +38,10 @@ module Vault
         subject.set_certificate("sample", certificate)
         result = subject.certificate("sample")
         expect(result).to be_a(Vault::Secret)
-        expect(result.data).to eq(certificate)
+        expect(result.data[:display_name]).to eq(certificate[:display_name])
+        expect(result.data[:certificate]).to eq(certificate[:certificate])
+        expect(result.data[:ttl]).to eq(certificate[:ttl])
+        expect(result.data[:policies]).to eq(certificate[:policies]).or eq([certificate[:policies]])
       end
 
       it "returns nil when the certificate does not exist" do


### PR DESCRIPTION
See https://github.com/hashicorp/vault/blob/master/CHANGELOG.md#083-september-19th-2017 

> Policy input/output standardization: For all built-in authentication backends, policies can now be specified as a comma-delimited string or an array if using JSON as API input; on read, policies will be returned as an array; and the default policy will not be forcefully added to policies saved in configurations. Please note that the default policy will continue to be added to generated tokens, however, rather than backends adding default to the given set of input policies (in some cases, and not in others), the stored set will reflect the user-specified set.

This "fixes" #151 in that all tests will now pass thru 0.8.3 (but not 0.9.x). It does not make any changes to address the API calls deprecated in 0.8.