### PR TITLE
Refactor Configurable accessor creation for readability

### DIFF
--- a/lib/vault/configurable.rb
+++ b/lib/vault/configurable.rb
@@ -27,7 +27,7 @@ module Vault
       ]
     end
 
-    Vault::Configurable.keys.each(&method(:attr_accessor))
+    attr_accessor *Vault::Configurable.keys
 
     # Configure yields self for block-style configuration.
     #


### PR DESCRIPTION
Thank you very much for this project! It's helped me learn a lot about build a configurable object with Ruby.

Seems like the implementation is the same, but this way is more readable:

```
ruby <<EOF
class C
  [:foo].each(&method(:attr_accessor))
  attr_accessor *[:bar]
end

puts RUBY_VERSION
p C.instance_methods(false)
EOF
2.4.2
[:bar, :bar=, :foo, :foo=]
```
