### PR TITLE
Add gcp auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.gem
 *.rbc
 /.config
+/.vscode
 /coverage/
 /InstalledFiles
 /pkg/

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -186,6 +186,29 @@ module Vault
       return secret
     end
 
+    # Authenticate via the GCP authentication method. If authentication is
+    # successful, the resulting token will be stored on the client and used
+    # for future requests.
+    #
+    # @example
+    #   Vault.auth.gcp("read-only", "jwt", "gcp") #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] role
+    # @param [String] jwt
+    #   jwt returned by the instance identity metadata
+    # @param [String] path optional
+    #   the path were the gcp auth backend is mounted
+    #
+    # @return [Secret]
+    def gcp(role, jwt, path = 'gcp')
+      payload = { role: role, jwt: jwt }
+      # Set a custom nonce if client is providing one
+      json = client.post("/v1/auth/#{CGI.escape(path)}/login", JSON.fast_generate(payload))
+      secret = Secret.decode(json)
+      client.token = secret.auth.client_token
+      return secret
+    end
+
     # Authenticate via a TLS authentication method. If authentication is
     # successful, the resulting token will be stored on the client and used
     # for future requests.

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -251,14 +251,13 @@ module Vault
     #
     # @param [String] role
     # @param [String] jwt
-    #   jwt returned by the instance identity metadata
+    #   jwt returned by the instance identity metadata, or iam api
     # @param [String] path optional
     #   the path were the gcp auth backend is mounted
     #
     # @return [Secret]
     def gcp(role, jwt, path = 'gcp')
       payload = { role: role, jwt: jwt }
-      # Set a custom nonce if client is providing one
       json = client.post("/v1/auth/#{CGI.escape(path)}/login", JSON.fast_generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -272,7 +272,7 @@ module Vault
       end
 
       let!(:old_token) { subject.token }
-      
+
       let(:jwt) do
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyLCJwcm9qZWN0X2lkIjoicHJvamVjdF9pZCJ9.TmuiSHtbLMZuw_LOzKWQ2vnC7BUvu2b4CeBXdxCDCXQ"
       end
@@ -283,7 +283,7 @@ module Vault
 
       it "does not authenticate if project_id does not match" do
         pending "gcp auth requires real resources and keys"
-        
+
         expect do
           subject.auth.gcp("rspec_wrong_role", jwt)
         end.to raise_error(Vault::HTTPClientError, /project_id doesn't match/)


### PR DESCRIPTION
This change adds the ability to get a token by using the GCP auth backend.
Tests are pending due to the nature of the backend requiring real service accounts and projects.

See #165 