### PR TITLE
support HTTP basic authn

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -242,6 +242,9 @@ module Vault
       # Build the URI and request object from the given information
       uri = build_uri(verb, path, data)
       request = class_for_request(verb).new(uri.request_uri)
+      if uri.userinfo()
+        request.basic_auth uri.user, uri.password
+      end
 
       if proxy_address and uri.scheme.downcase == "https"
         raise SecurityError, "no direct https connection to vault"


### PR DESCRIPTION
I expose Vault on a semi-untrusted network using a reverse proxy with HTTP authentication. The Vault gem didn't honor an address with a username and password in the URL.