### PR TITLE
support sane defaults for jruby ssl_ciphers

### DIFF
--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -14,7 +14,7 @@ module Vault
     # The list of SSL ciphers to allow. You should not change this value unless
     # you absolutely know what you are doing!
     # @return [String]
-    SSL_CIPHERS = "TLSv1.2:!aNULL:!eNULL".freeze
+    SSL_CIPHERS = RUBY_PLATFORM == 'java' ? "TLSv1.0:!aNULL:!eNULL".freeze : "TLSv1.2:!aNULL:!eNULL".freeze
 
     # The default number of attempts.
     # @return [Fixnum]


### PR DESCRIPTION
Updates the SSL_CIPHERS frozen string with logic for sane defaults for JRuby.



This is a quick fix for everyone running into #179 and who are unable to find the issue for assistance. A more complete fix would be appreciated afterward.