### PR TITLE
Support for Vault 0.9-0.11, including versioned kv secrets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: ruby
 cache: bundler
 
 env:
+  - VAULT_VERSION=0.11.4
+  - VAULT_VERSION=0.10.4
+  - VAULT_VERSION=0.9.6
   - VAULT_VERSION=0.8.3
   - VAULT_VERSION=0.7.3
   - VAULT_VERSION=0.6.5

--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -1,231 +1,28 @@
-require_relative "secret"
-require_relative "../client"
-require_relative "../request"
-require_relative "../response"
+require_relative "logical/unversioned"
+require_relative "logical/versioned"
 
 module Vault
   class Client
+    LOGICAL_APPROACHES = {
+      unversioned: Logical::Unversioned,
+      versioned:   Logical::Versioned
+    }.freeze
+
     # A proxy to the {Logical} methods.
-    # @return [Logical]
-    def logical
-      @logical ||= Logical.new(self)
+    # @return [Logical::Unversioned, Logical::Versioned]
+    def logical(approach = :unversioned)
+      logicals[approach]
     end
 
-    def versioned_logical
-      @logical ||= VersionedLogical.new(self)
+    private
+
+    def logicals
+      @logicals ||= Hash.new do |hash, key|
+        hash[key] = LOGICAL_APPROACHES.fetch(key).new(self)
+      end
     end
   end
 
-  class Logical < Request
-    # List the secrets at the given path, if the path supports listing. If the
-    # the path does not exist, an exception will be raised.
-    #
-    # @example
-    #   Vault.logical.list("secret") #=> [#<Vault::Secret>, #<Vault::Secret>, ...]
-    #
-    # @param [String] path
-    #   the path to list
-    #
-    # @return [Array<String>]
-    def list(path, options = {})
-      headers = extract_headers!(options)
-      json = client.list("/v1/#{encode_path(path)}", {}, headers)
-      json[:data][:keys] || []
-    rescue HTTPError => e
-      return [] if e.code == 404
-      raise
-    end
-
-    # Read the secret at the given path. If the secret does not exist, +nil+
-    # will be returned.
-    #
-    # @example
-    #   Vault.logical.read("secret/password") #=> #<Vault::Secret lease_id="">
-    #
-    # @param [String] path
-    #   the path to read
-    #
-    # @return [Secret, nil]
-    def read(path, options = {})
-      headers = extract_headers!(options)
-      json = client.get("/v1/#{encode_path(path)}", {}, headers)
-      return Secret.decode(json)
-    rescue HTTPError => e
-      return nil if e.code == 404
-      raise
-    end
-
-    # Write the secret at the given path with the given data. Note that the
-    # data must be a {Hash}!
-    #
-    # @example
-    #   Vault.logical.write("secret/password", value: "secret") #=> #<Vault::Secret lease_id="">
-    #
-    # @param [String] path
-    #   the path to write
-    # @param [Hash] data
-    #   the data to write
-    #
-    # @return [Secret]
-    def write(path, data = {}, options = {})
-      headers = extract_headers!(options)
-      json = client.put("/v1/#{encode_path(path)}", JSON.fast_generate(data), headers)
-      if json.nil?
-        return true
-      else
-        return Secret.decode(json)
-      end
-    end
-
-    # Delete the secret at the given path. If the secret does not exist, vault
-    # will still return true.
-    #
-    # @example
-    #   Vault.logical.delete("secret/password") #=> true
-    #
-    # @param [String] path
-    #   the path to delete
-    #
-    # @return [true]
-    def delete(path)
-      client.delete("/v1/#{encode_path(path)}")
-      return true
-    end
-
-    # Unwrap the data stored against the given token. If the secret does not
-    # exist, `nil` will be returned.
-    #
-    # @example
-    #   Vault.logical.unwrap("f363dba8-25a7-08c5-430c-00b2367124e6") #=> #<Vault::Secret lease_id="">
-    #
-    # @param [String] wrapper
-    #   the token to use when unwrapping the value
-    #
-    # @return [Secret, nil]
-    def unwrap(wrapper)
-      client.with_token(wrapper) do |client|
-        json = client.get("/v1/cubbyhole/response")
-        secret = Secret.decode(json)
-
-        # If there is nothing in the cubbyhole, return early.
-        if secret.nil? || secret.data.nil? || secret.data[:response].nil?
-          return nil
-        end
-
-        # Extract the response and parse it into a new secret.
-        json = JSON.parse(secret.data[:response], symbolize_names: true)
-        secret = Secret.decode(json)
-        return secret
-      end
-    rescue HTTPError => e
-      return nil if e.code == 404
-      raise
-    end
-
-    # Unwrap a token in a wrapped response given the temporary token.
-    #
-    # @example
-    #   Vault.logical.unwrap("f363dba8-25a7-08c5-430c-00b2367124e6") #=> "0f0f40fd-06ce-4af1-61cb-cdc12796f42b"
-    #
-    # @param [String, Secret] wrapper
-    #   the token to unwrap
-    #
-    # @return [String, nil]
-    def unwrap_token(wrapper)
-      # If provided a secret, grab the token. This is really just to make the
-      # API a bit nicer.
-      if wrapper.is_a?(Secret)
-        wrapper = wrapper.wrap_info.token
-      end
-
-      # Unwrap
-      response = unwrap(wrapper)
-
-      # If nothing was there, return nil
-      if response.nil? || response.auth.nil?
-        return nil
-      end
-
-      return response.auth.client_token
-    rescue HTTPError => e
-      raise
-    end
-  end
-
-  class VersionedLogical < Logical
-    # List the secrets at the given path, if the path supports listing. If the
-    # the path does not exist, an exception will be raised.
-    #
-    # @example
-    #   Vault.logical.list("secret") #=> [#<Vault::Secret>, #<Vault::Secret>, ...]
-    #
-    # @param [String] path
-    #   the path to list
-    #
-    # @return [Array<String>]
-    def list(mount, path = "", options = {})
-      headers = extract_headers!(options)
-      json = client.list("/v1/#{mount}/metadata/#{encode_path(path)}", {}, headers)
-      json[:data][:keys] || []
-    rescue HTTPError => e
-      return [] if e.code == 404
-      raise
-    end
-
-    # Read the secret at the given path. If the secret does not exist, +nil+
-    # will be returned.
-    #
-    # @example
-    #   Vault.logical.read("secret/password") #=> #<Vault::Secret lease_id="">
-    #
-    # @param [String] path
-    #   the path to read
-    #
-    # @return [Secret, nil]
-    def read(mount, path, options = {})
-      headers = extract_headers!(options)
-      json = client.get("/v1/#{mount}/data/#{encode_path(path)}", {}, headers)
-      return Secret.decode(json[:data])
-    rescue HTTPError => e
-      return nil if e.code == 404
-      raise
-    end
-
-    # Write the secret at the given path with the given data. Note that the
-    # data must be a {Hash}!
-    #
-    # @example
-    #   Vault.logical.write("secret/password", value: "secret") #=> #<Vault::Secret lease_id="">
-    #
-    # @param [String] path
-    #   the path to write
-    # @param [Hash] data
-    #   the data to write
-    #
-    # @return [Secret]
-    def write(mount, path, data = {}, options = {})
-      headers = extract_headers!(options)
-      json = client.post("/v1/#{mount}/data/#{encode_path(path)}", JSON.fast_generate(:data => data), headers)
-      if json.nil?
-        return true
-      else
-        return Secret.decode(json)
-      end
-    end
-
-    # Delete the secret at the given path. If the secret does not exist, vault
-    # will still return true.
-    #
-    # @example
-    #   Vault.logical.delete("secret/password") #=> true
-    #
-    # @param [String] path
-    #   the path to delete
-    #
-    # @return [true]
-    def delete(mount, path)
-      client.delete("/v1/#{mount}/data/#{encode_path(path)}")
-      return true
-    end
+  module Logical
   end
 end

--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -10,6 +10,10 @@ module Vault
     def logical
       @logical ||= Logical.new(self)
     end
+
+    def versioned_logical
+      @logical ||= VersionedLogical.new(self)
+    end
   end
 
   class Logical < Request
@@ -145,6 +149,83 @@ module Vault
       return response.auth.client_token
     rescue HTTPError => e
       raise
+    end
+  end
+
+  class VersionedLogical < Logical
+    # List the secrets at the given path, if the path supports listing. If the
+    # the path does not exist, an exception will be raised.
+    #
+    # @example
+    #   Vault.logical.list("secret") #=> [#<Vault::Secret>, #<Vault::Secret>, ...]
+    #
+    # @param [String] path
+    #   the path to list
+    #
+    # @return [Array<String>]
+    def list(mount, path = "", options = {})
+      headers = extract_headers!(options)
+      json = client.list("/v1/#{mount}/metadata/#{encode_path(path)}", {}, headers)
+      json[:data][:keys] || []
+    rescue HTTPError => e
+      return [] if e.code == 404
+      raise
+    end
+
+    # Read the secret at the given path. If the secret does not exist, +nil+
+    # will be returned.
+    #
+    # @example
+    #   Vault.logical.read("secret/password") #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] path
+    #   the path to read
+    #
+    # @return [Secret, nil]
+    def read(mount, path, options = {})
+      headers = extract_headers!(options)
+      json = client.get("/v1/#{mount}/data/#{encode_path(path)}", {}, headers)
+      return Secret.decode(json[:data])
+    rescue HTTPError => e
+      return nil if e.code == 404
+      raise
+    end
+
+    # Write the secret at the given path with the given data. Note that the
+    # data must be a {Hash}!
+    #
+    # @example
+    #   Vault.logical.write("secret/password", value: "secret") #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] path
+    #   the path to write
+    # @param [Hash] data
+    #   the data to write
+    #
+    # @return [Secret]
+    def write(mount, path, data = {}, options = {})
+      headers = extract_headers!(options)
+      json = client.post("/v1/#{mount}/data/#{encode_path(path)}", JSON.fast_generate(:data => data), headers)
+      if json.nil?
+        return true
+      else
+        return Secret.decode(json)
+      end
+    end
+
+    # Delete the secret at the given path. If the secret does not exist, vault
+    # will still return true.
+    #
+    # @example
+    #   Vault.logical.delete("secret/password") #=> true
+    #
+    # @param [String] path
+    #   the path to delete
+    #
+    # @return [true]
+    def delete(mount, path)
+      client.delete("/v1/#{mount}/data/#{encode_path(path)}")
+      return true
     end
   end
 end

--- a/lib/vault/api/logical/unversioned.rb
+++ b/lib/vault/api/logical/unversioned.rb
@@ -1,0 +1,144 @@
+require_relative "../secret"
+require_relative "../../client"
+require_relative "../../request"
+require_relative "../../response"
+
+module Vault
+  module Logical
+    class Unversioned < Request
+      # List the secrets at the given path, if the path supports listing. If the
+      # the path does not exist, an exception will be raised.
+      #
+      # @example
+      #   Vault.logical.list("secret") #=> [#<Vault::Secret>, #<Vault::Secret>, ...]
+      #
+      # @param [String] path
+      #   the path to list
+      #
+      # @return [Array<String>]
+      def list(path, options = {})
+        headers = extract_headers!(options)
+        json = client.list("/v1/#{encode_path(path)}", {}, headers)
+        json[:data][:keys] || []
+      rescue HTTPError => e
+        return [] if e.code == 404
+        raise
+      end
+
+      # Read the secret at the given path. If the secret does not exist, +nil+
+      # will be returned.
+      #
+      # @example
+      #   Vault.logical.read("secret/password") #=> #<Vault::Secret lease_id="">
+      #
+      # @param [String] path
+      #   the path to read
+      #
+      # @return [Secret, nil]
+      def read(path, options = {})
+        headers = extract_headers!(options)
+        json = client.get("/v1/#{encode_path(path)}", {}, headers)
+        return Secret.decode(json)
+      rescue HTTPError => e
+        return nil if e.code == 404
+        raise
+      end
+
+      # Write the secret at the given path with the given data. Note that the
+      # data must be a {Hash}!
+      #
+      # @example
+      #   Vault.logical.write("secret/password", value: "secret") #=> #<Vault::Secret lease_id="">
+      #
+      # @param [String] path
+      #   the path to write
+      # @param [Hash] data
+      #   the data to write
+      #
+      # @return [Secret]
+      def write(path, data = {}, options = {})
+        headers = extract_headers!(options)
+        json = client.put("/v1/#{encode_path(path)}", JSON.fast_generate(data), headers)
+        if json.nil?
+          return true
+        else
+          return Secret.decode(json)
+        end
+      end
+
+      # Delete the secret at the given path. If the secret does not exist, vault
+      # will still return true.
+      #
+      # @example
+      #   Vault.logical.delete("secret/password") #=> true
+      #
+      # @param [String] path
+      #   the path to delete
+      #
+      # @return [true]
+      def delete(path)
+        client.delete("/v1/#{encode_path(path)}")
+        return true
+      end
+
+      # Unwrap the data stored against the given token. If the secret does not
+      # exist, `nil` will be returned.
+      #
+      # @example
+      #   Vault.logical.unwrap("f363dba8-25a7-08c5-430c-00b2367124e6") #=> #<Vault::Secret lease_id="">
+      #
+      # @param [String] wrapper
+      #   the token to use when unwrapping the value
+      #
+      # @return [Secret, nil]
+      def unwrap(wrapper)
+        client.with_token(wrapper) do |client|
+          json = client.get("/v1/cubbyhole/response")
+          secret = Secret.decode(json)
+
+          # If there is nothing in the cubbyhole, return early.
+          if secret.nil? || secret.data.nil? || secret.data[:response].nil?
+            return nil
+          end
+
+          # Extract the response and parse it into a new secret.
+          json = JSON.parse(secret.data[:response], symbolize_names: true)
+          secret = Secret.decode(json)
+          return secret
+        end
+      rescue HTTPError => e
+        return nil if e.code == 404
+        raise
+      end
+
+      # Unwrap a token in a wrapped response given the temporary token.
+      #
+      # @example
+      #   Vault.logical.unwrap("f363dba8-25a7-08c5-430c-00b2367124e6") #=> "0f0f40fd-06ce-4af1-61cb-cdc12796f42b"
+      #
+      # @param [String, Secret] wrapper
+      #   the token to unwrap
+      #
+      # @return [String, nil]
+      def unwrap_token(wrapper)
+        # If provided a secret, grab the token. This is really just to make the
+        # API a bit nicer.
+        if wrapper.is_a?(Secret)
+          wrapper = wrapper.wrap_info.token
+        end
+
+        # Unwrap
+        response = unwrap(wrapper)
+
+        # If nothing was there, return nil
+        if response.nil? || response.auth.nil?
+          return nil
+        end
+
+        return response.auth.client_token
+      rescue HTTPError => e
+        raise
+      end
+    end
+  end
+end

--- a/lib/vault/api/logical/versioned.rb
+++ b/lib/vault/api/logical/versioned.rb
@@ -13,6 +13,8 @@ module Vault
       # @example
       #   Vault.logical.list("secret") #=> [#<Vault::Secret>, #<Vault::Secret>, ...]
       #
+      # @param [String] mount
+      #   the mount point for the secret engine
       # @param [String] path
       #   the path to list
       #
@@ -32,6 +34,8 @@ module Vault
       # @example
       #   Vault.logical.read("secret/password") #=> #<Vault::Secret lease_id="">
       #
+      # @param [String] mount
+      #   the mount point for the secret engine
       # @param [String] path
       #   the path to read
       #
@@ -51,6 +55,8 @@ module Vault
       # @example
       #   Vault.logical.write("secret/password", value: "secret") #=> #<Vault::Secret lease_id="">
       #
+      # @param [String] mount
+      #   the mount point for the secret engine
       # @param [String] path
       #   the path to write
       # @param [Hash] data
@@ -73,6 +79,8 @@ module Vault
       # @example
       #   Vault.logical.delete("secret/password") #=> true
       #
+      # @param [String] mount
+      #   the mount point for the secret engine
       # @param [String] path
       #   the path to delete
       #

--- a/lib/vault/api/logical/versioned.rb
+++ b/lib/vault/api/logical/versioned.rb
@@ -1,0 +1,86 @@
+require_relative "unversioned"
+require_relative "../secret"
+require_relative "../../client"
+require_relative "../../request"
+require_relative "../../response"
+
+module Vault
+  module Logical
+    class Versioned < Unversioned
+      # List the secrets at the given path, if the path supports listing. If the
+      # the path does not exist, an exception will be raised.
+      #
+      # @example
+      #   Vault.logical.list("secret") #=> [#<Vault::Secret>, #<Vault::Secret>, ...]
+      #
+      # @param [String] path
+      #   the path to list
+      #
+      # @return [Array<String>]
+      def list(mount, path = "", options = {})
+        headers = extract_headers!(options)
+        json = client.list("/v1/#{mount}/metadata/#{encode_path(path)}", {}, headers)
+        json[:data][:keys] || []
+      rescue HTTPError => e
+        return [] if e.code == 404
+        raise
+      end
+
+      # Read the secret at the given path. If the secret does not exist, +nil+
+      # will be returned.
+      #
+      # @example
+      #   Vault.logical.read("secret/password") #=> #<Vault::Secret lease_id="">
+      #
+      # @param [String] path
+      #   the path to read
+      #
+      # @return [Secret, nil]
+      def read(mount, path, options = {})
+        headers = extract_headers!(options)
+        json = client.get("/v1/#{mount}/data/#{encode_path(path)}", {}, headers)
+        return Secret.decode(json[:data])
+      rescue HTTPError => e
+        return nil if e.code == 404
+        raise
+      end
+
+      # Write the secret at the given path with the given data. Note that the
+      # data must be a {Hash}!
+      #
+      # @example
+      #   Vault.logical.write("secret/password", value: "secret") #=> #<Vault::Secret lease_id="">
+      #
+      # @param [String] path
+      #   the path to write
+      # @param [Hash] data
+      #   the data to write
+      #
+      # @return [Secret]
+      def write(mount, path, data = {}, options = {})
+        headers = extract_headers!(options)
+        json = client.post("/v1/#{mount}/data/#{encode_path(path)}", JSON.fast_generate(:data => data), headers)
+        if json.nil?
+          return true
+        else
+          return Secret.decode(json)
+        end
+      end
+
+      # Delete the secret at the given path. If the secret does not exist, vault
+      # will still return true.
+      #
+      # @example
+      #   Vault.logical.delete("secret/password") #=> true
+      #
+      # @param [String] path
+      #   the path to delete
+      #
+      # @return [true]
+      def delete(mount, path)
+        client.delete("/v1/#{mount}/data/#{encode_path(path)}")
+        return true
+      end
+    end
+  end
+end

--- a/lib/vault/api/logical/versioned.rb
+++ b/lib/vault/api/logical/versioned.rb
@@ -32,7 +32,7 @@ module Vault
       # will be returned.
       #
       # @example
-      #   Vault.logical.read("secret/password") #=> #<Vault::Secret lease_id="">
+      #   Vault.logical.read("secret", "password") #=> #<Vault::Secret lease_id="">
       #
       # @param [String] mount
       #   the mount point for the secret engine
@@ -53,7 +53,7 @@ module Vault
       # data must be a {Hash}!
       #
       # @example
-      #   Vault.logical.write("secret/password", value: "secret") #=> #<Vault::Secret lease_id="">
+      #   Vault.logical.write("secret", "password", value: "secret") #=> #<Vault::Secret lease_id="">
       #
       # @param [String] mount
       #   the mount point for the secret engine
@@ -77,7 +77,7 @@ module Vault
       # will still return true.
       #
       # @example
-      #   Vault.logical.delete("secret/password") #=> true
+      #   Vault.logical.delete("secret", "password") #=> true
       #
       # @param [String] mount
       #   the mount point for the secret engine

--- a/lib/vault/api/secret.rb
+++ b/lib/vault/api/secret.rb
@@ -32,6 +32,18 @@ module Vault
     #   @return [Hash<Symbol, Object>]
     field :data, freeze: true
 
+    # @!attribute [r] metadata
+    #   Read-only metadata information related to the secret.
+    #
+    #   @example Reading metadata
+    #     secret = Vault.logical(:versioned).read("secret", "foo")
+    #     secret.metadata[:created_time] #=> "2018-12-08T04:22:54.168065Z"
+    #     secret.metadata[:version]      #=> 1
+    #     secret.metadata[:destroyed]    #=> false
+    #
+    #   @return [Hash<Symbol, Object>]
+    field :metadata, freeze: true
+
     # @!attribute [r] lease_duration
     #   The number of seconds this lease is valid. If this number is 0 or nil,
     #   the secret does not expire.

--- a/lib/vault/api/sys/mount.rb
+++ b/lib/vault/api/sys/mount.rb
@@ -44,8 +44,8 @@ module Vault
     #   the type of mount
     # @param [String] description
     #   a human-friendly description (optional)
-    def mount(path, type, description = nil)
-      payload = { type: type }
+    def mount(path, type, description = nil, options = {})
+      payload = options.merge type: type
       payload[:description] = description if !description.nil?
 
       client.post("/v1/sys/mounts/#{encode_path(path)}", JSON.fast_generate(payload))

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -261,6 +261,8 @@ module Vault
 
     describe "#gcp", vault: ">= 0.8.1" do
       before(:context) do
+        skip "gcp auth requires real resources and keys"
+
         vault_test_client.sys.enable_auth("gcp", "gcp", nil)
         vault_test_client.post("/v1/auth/gcp/config", JSON.fast_generate("service_account" => "rspec_service_account"))
         vault_test_client.post("/v1/auth/gcp/role/rspec_wrong_role", JSON.fast_generate("name" => "rspec_role", "project_id" => "wrong_project_id", "bound_service_accounts" => "\*", "type" => "iam"))

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -244,7 +244,7 @@ module Vault
         )
         expect do
           subject.auth.aws_iam('a_rolename', credentials_provider, 'mismatched_iam_header', 'https://sts.cn-north-1.amazonaws.com.cn') 
-        end.to raise_error(Vault::HTTPClientError, /expected iam_header_canary but got mismatched_iam_header/)
+        end.to raise_error(Vault::HTTPClientError, /expected "?iam_header_canary"? but got "?mismatched_iam_header"?/)
       end
 
       it "authenticates and saves the token on the client" do

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -1,17 +1,17 @@
 require "spec_helper"
 
 module Vault
-  describe Logical do
-    subject { vault_test_client.logical }
+  describe VersionedLogical do
+    subject { vault_test_client.versioned_logical }
 
     describe "#list" do
       it "returns the empty array when no items exist" do
-        expect(subject.list("secret/that/never/existed")).to eq([])
+        expect(subject.list("secret", "that/never/existed")).to eq([])
       end
 
       it "returns all secrets" do
-        subject.write("secret/test-list-1", foo: "bar")
-        subject.write("secret/test-list-2", foo: "bar")
+        subject.write("secret", "test-list-1", foo: "bar")
+        subject.write("secret", "test-list-2", foo: "bar")
         secrets = subject.list("secret")
         expect(secrets).to be_a(Array)
         expect(secrets).to include("test-list-1")
@@ -21,19 +21,19 @@ module Vault
 
     describe "#read" do
       it "returns nil with the thing does not exist" do
-        expect(subject.read("secret/foo/bar/zip")).to be(nil)
+        expect(subject.read("secret", "foo/bar/zip")).to be(nil)
       end
 
       it "returns the secret when it exists" do
-        subject.write("secret/test-read", foo: "bar")
-        secret = subject.read("secret/test-read")
+        subject.write("secret", "test-read", foo: "bar")
+        secret = subject.read("secret", "test-read")
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-read", foo: "bar")
-        secret = subject.read("secret/b:@c%n-read")
+        subject.write("secret", "b:@c%n-read", foo: "bar")
+        secret = subject.read("secret", "b:@c%n-read")
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
@@ -41,33 +41,33 @@ module Vault
 
     describe "#write" do
       it "creates and returns the secret" do
-        subject.write("secret/test-write", zip: "zap")
-        result = subject.read("secret/test-write")
+        subject.write("secret", "test-write", zip: "zap")
+        result = subject.read("secret", "test-write")
         expect(result).to be
         expect(result.data).to eq(zip: "zap")
       end
 
       it "overwrites existing secrets" do
-        subject.write("secret/test-overwrite", zip: "zap")
-        subject.write("secret/test-overwrite", bacon: true)
-        result = subject.read("secret/test-overwrite")
+        subject.write("secret", "test-overwrite", zip: "zap")
+        subject.write("secret", "test-overwrite", bacon: true)
+        result = subject.read("secret", "test-overwrite")
         expect(result).to be
         expect(result.data).to eq(bacon: true)
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-write", foo: "bar")
-        subject.write("secret/b:@c%n-write", bacon: true)
-        secret = subject.read("secret/b:@c%n-write")
+        subject.write("secret", "b:@c%n-write", foo: "bar")
+        subject.write("secret", "b:@c%n-write", bacon: true)
+        secret = subject.read("secret", "b:@c%n-write")
         expect(secret).to be
         expect(secret.data).to eq(bacon: true)
       end
 
       it "respects spaces properly" do
-        key = 'secret/sub/"Test Group"'
-        subject.write(key, foo: "bar")
-        expect(subject.list("secret/sub")).to eq(['"Test Group"'])
-        secret = subject.read(key)
+        key = 'sub/"Test Group"'
+        subject.write("secret", key, foo: "bar")
+        expect(subject.list("secret", "sub")).to eq(['"Test Group"'])
+        secret = subject.read("secret", key)
         expect(secret).to be
         expect(secret.data).to eq(foo:"bar")
       end
@@ -75,22 +75,22 @@ module Vault
 
     describe "#delete" do
       it "deletes the secret" do
-        subject.write("secret/delete", foo: "bar")
-        expect(subject.delete("secret/delete")).to be(true)
-        expect(subject.read("secret/delete")).to be(nil)
+        subject.write("secret", "delete", foo: "bar")
+        expect(subject.delete("secret", "delete")).to be(true)
+        expect(subject.read("secret", "delete")).to be(nil)
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-delete", foo: "bar")
-        expect(subject.delete("secret/b:@c%n-delete")).to be(true)
-        expect(subject.read("secret/b:@c%n-delete")).to be(nil)
+        subject.write("secret", "b:@c%n-delete", foo: "bar")
+        expect(subject.delete("secret", "b:@c%n-delete")).to be(true)
+        expect(subject.read("secret", "b:@c%n-delete")).to be(nil)
       end
 
       it "does not error if the secret does not exist" do
         expect {
-          subject.delete("secret/delete")
-          subject.delete("secret/delete")
-          subject.delete("secret/delete")
+          subject.delete("secret", "delete")
+          subject.delete("secret", "delete")
+          subject.delete("secret", "delete")
         }.to_not raise_error
       end
     end
@@ -104,7 +104,7 @@ module Vault
         expect(unwrapped.auth.client_token).to be
 
         vault_test_client.with_token(unwrapped.auth.client_token) do |client|
-          expect { client.logical.read("secret/test") }.to_not raise_error
+          expect { client.logical2.read("secret", "test") }.to_not raise_error
         end
       end
     end
@@ -117,7 +117,7 @@ module Vault
         expect(unwrapped).to be
 
         vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical.read("secret/test") }.to_not raise_error
+          expect { client.logical2.read("secret", "test") }.to_not raise_error
         end
       end
 
@@ -128,7 +128,154 @@ module Vault
         expect(unwrapped).to be
 
         vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical.read("secret/test") }.to_not raise_error
+          expect { client.logical2.read("secret", "test") }.to_not raise_error
+        end
+      end
+
+      it "returns nil when the response is empty" do
+        token = vault_test_client.auth_token.create # Note no wrap-ttl here
+        unwrapped = subject.unwrap_token(token.auth.client_token)
+        expect(unwrapped).to be(nil)
+      end
+    end
+  end
+
+  describe Logical do
+    subject { vault_test_client.logical }
+
+    before(:context) do
+      vault_test_client.sys.mount("legacy-secret", "kv", "", version: 1)
+    end
+
+    after(:context) do
+      vault_test_client.sys.unmount("legacy-secret")
+    end
+
+    describe "#list" do
+      it "returns the empty array when no items exist" do
+        expect(subject.list("legacy-secret/that/never/existed")).to eq([])
+      end
+
+      it "returns all secrets" do
+        subject.write("legacy-secret/test-list-1", foo: "bar")
+        subject.write("legacy-secret/test-list-2", foo: "bar")
+        secrets = subject.list("legacy-secret")
+        expect(secrets).to be_a(Array)
+        expect(secrets).to include("test-list-1")
+        expect(secrets).to include("test-list-2")
+      end
+    end
+
+    describe "#read" do
+      it "returns nil with the thing does not exist" do
+        expect(subject.read("legacy-secret/foo/bar/zip")).to be(nil)
+      end
+
+      it "returns the secret when it exists" do
+        subject.write("legacy-secret/test-read", foo: "bar")
+        secret = subject.read("legacy-secret/test-read")
+        expect(secret).to be
+        expect(secret.data).to eq(foo: "bar")
+      end
+
+      it "allows special characters" do
+        subject.write("legacy-secret/b:@c%n-read", foo: "bar")
+        secret = subject.read("legacy-secret/b:@c%n-read")
+        expect(secret).to be
+        expect(secret.data).to eq(foo: "bar")
+      end
+    end
+
+    describe "#write" do
+      it "creates and returns the secret" do
+        subject.write("legacy-secret/test-write", zip: "zap")
+        result = subject.read("legacy-secret/test-write")
+        expect(result).to be
+        expect(result.data).to eq(zip: "zap")
+      end
+
+      it "overwrites existing secrets" do
+        subject.write("legacy-secret/test-overwrite", zip: "zap")
+        subject.write("legacy-secret/test-overwrite", bacon: true)
+        result = subject.read("legacy-secret/test-overwrite")
+        expect(result).to be
+        expect(result.data).to eq(bacon: true)
+      end
+
+      it "allows special characters" do
+        subject.write("legacy-secret/b:@c%n-write", foo: "bar")
+        subject.write("legacy-secret/b:@c%n-write", bacon: true)
+        secret = subject.read("legacy-secret/b:@c%n-write")
+        expect(secret).to be
+        expect(secret.data).to eq(bacon: true)
+      end
+
+      it "respects spaces properly" do
+        key = 'legacy-secret/sub/"Test Group"'
+        subject.write(key, foo: "bar")
+        expect(subject.list("legacy-secret/sub")).to eq(['"Test Group"'])
+        secret = subject.read(key)
+        expect(secret).to be
+        expect(secret.data).to eq(foo:"bar")
+      end
+    end
+
+    describe "#delete" do
+      it "deletes the secret" do
+        subject.write("legacy-secret/delete", foo: "bar")
+        expect(subject.delete("legacy-secret/delete")).to be(true)
+        expect(subject.read("legacy-secret/delete")).to be(nil)
+      end
+
+      it "allows special characters" do
+        subject.write("legacy-secret/b:@c%n-delete", foo: "bar")
+        expect(subject.delete("legacy-secret/b:@c%n-delete")).to be(true)
+        expect(subject.read("legacy-secret/b:@c%n-delete")).to be(nil)
+      end
+
+      it "does not error if the secret does not exist" do
+        expect {
+          subject.delete("legacy-secret/delete")
+          subject.delete("legacy-secret/delete")
+          subject.delete("legacy-secret/delete")
+        }.to_not raise_error
+      end
+    end
+
+    describe "#unwrap", vault: ">= 0.6" do
+      it "returns the wrapped secret when it exists" do
+        wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
+        unwrapped = subject.unwrap(wrapped.wrap_info.token)
+
+        expect(unwrapped.auth).to be
+        expect(unwrapped.auth.client_token).to be
+
+        vault_test_client.with_token(unwrapped.auth.client_token) do |client|
+          expect { client.logical.read("legacy-secret/test") }.to_not raise_error
+        end
+      end
+    end
+
+    describe "#unwrap_token", vault: ">= 0.6" do
+      it "returns the wrapped token when given a string" do
+        wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
+        unwrapped = subject.unwrap_token(wrapped.wrap_info.token)
+
+        expect(unwrapped).to be
+
+        vault_test_client.with_token(unwrapped) do |client|
+          expect { client.logical.read("legacy-secret/test") }.to_not raise_error
+        end
+      end
+
+      it "returns the wrapped token when given a Vault::Secret" do
+        wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
+        unwrapped = subject.unwrap_token(wrapped)
+
+        expect(unwrapped).to be
+
+        vault_test_client.with_token(unwrapped) do |client|
+          expect { client.logical.read("legacy-secret/test") }.to_not raise_error
         end
       end
 

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -1,288 +1,290 @@
 require "spec_helper"
 
 module Vault
-  describe VersionedLogical do
-    subject { vault_test_client.versioned_logical }
+  module Logical
+    describe Versioned, vault: ">= 0.10" do
+      subject { vault_test_client.logical(:versioned) }
 
-    describe "#list" do
-      it "returns the empty array when no items exist" do
-        expect(subject.list("secret", "that/never/existed")).to eq([])
+      describe "#list" do
+        it "returns the empty array when no items exist" do
+          expect(subject.list("secret", "that/never/existed")).to eq([])
+        end
+
+        it "returns all secrets" do
+          subject.write("secret", "test-list-1", foo: "bar")
+          subject.write("secret", "test-list-2", foo: "bar")
+          secrets = subject.list("secret")
+          expect(secrets).to be_a(Array)
+          expect(secrets).to include("test-list-1")
+          expect(secrets).to include("test-list-2")
+        end
       end
 
-      it "returns all secrets" do
-        subject.write("secret", "test-list-1", foo: "bar")
-        subject.write("secret", "test-list-2", foo: "bar")
-        secrets = subject.list("secret")
-        expect(secrets).to be_a(Array)
-        expect(secrets).to include("test-list-1")
-        expect(secrets).to include("test-list-2")
-      end
-    end
+      describe "#read" do
+        it "returns nil with the thing does not exist" do
+          expect(subject.read("secret", "foo/bar/zip")).to be(nil)
+        end
 
-    describe "#read" do
-      it "returns nil with the thing does not exist" do
-        expect(subject.read("secret", "foo/bar/zip")).to be(nil)
-      end
+        it "returns the secret when it exists" do
+          subject.write("secret", "test-read", foo: "bar")
+          secret = subject.read("secret", "test-read")
+          expect(secret).to be
+          expect(secret.data).to eq(foo: "bar")
+        end
 
-      it "returns the secret when it exists" do
-        subject.write("secret", "test-read", foo: "bar")
-        secret = subject.read("secret", "test-read")
-        expect(secret).to be
-        expect(secret.data).to eq(foo: "bar")
+        it "allows special characters" do
+          subject.write("secret", "b:@c%n-read", foo: "bar")
+          secret = subject.read("secret", "b:@c%n-read")
+          expect(secret).to be
+          expect(secret.data).to eq(foo: "bar")
+        end
       end
 
-      it "allows special characters" do
-        subject.write("secret", "b:@c%n-read", foo: "bar")
-        secret = subject.read("secret", "b:@c%n-read")
-        expect(secret).to be
-        expect(secret.data).to eq(foo: "bar")
-      end
-    end
+      describe "#write" do
+        it "creates and returns the secret" do
+          subject.write("secret", "test-write", zip: "zap")
+          result = subject.read("secret", "test-write")
+          expect(result).to be
+          expect(result.data).to eq(zip: "zap")
+        end
 
-    describe "#write" do
-      it "creates and returns the secret" do
-        subject.write("secret", "test-write", zip: "zap")
-        result = subject.read("secret", "test-write")
-        expect(result).to be
-        expect(result.data).to eq(zip: "zap")
-      end
+        it "overwrites existing secrets" do
+          subject.write("secret", "test-overwrite", zip: "zap")
+          subject.write("secret", "test-overwrite", bacon: true)
+          result = subject.read("secret", "test-overwrite")
+          expect(result).to be
+          expect(result.data).to eq(bacon: true)
+        end
 
-      it "overwrites existing secrets" do
-        subject.write("secret", "test-overwrite", zip: "zap")
-        subject.write("secret", "test-overwrite", bacon: true)
-        result = subject.read("secret", "test-overwrite")
-        expect(result).to be
-        expect(result.data).to eq(bacon: true)
-      end
+        it "allows special characters" do
+          subject.write("secret", "b:@c%n-write", foo: "bar")
+          subject.write("secret", "b:@c%n-write", bacon: true)
+          secret = subject.read("secret", "b:@c%n-write")
+          expect(secret).to be
+          expect(secret.data).to eq(bacon: true)
+        end
 
-      it "allows special characters" do
-        subject.write("secret", "b:@c%n-write", foo: "bar")
-        subject.write("secret", "b:@c%n-write", bacon: true)
-        secret = subject.read("secret", "b:@c%n-write")
-        expect(secret).to be
-        expect(secret.data).to eq(bacon: true)
-      end
-
-      it "respects spaces properly" do
-        key = 'sub/"Test Group"'
-        subject.write("secret", key, foo: "bar")
-        expect(subject.list("secret", "sub")).to eq(['"Test Group"'])
-        secret = subject.read("secret", key)
-        expect(secret).to be
-        expect(secret.data).to eq(foo:"bar")
-      end
-    end
-
-    describe "#delete" do
-      it "deletes the secret" do
-        subject.write("secret", "delete", foo: "bar")
-        expect(subject.delete("secret", "delete")).to be(true)
-        expect(subject.read("secret", "delete")).to be(nil)
+        it "respects spaces properly" do
+          key = 'sub/"Test Group"'
+          subject.write("secret", key, foo: "bar")
+          expect(subject.list("secret", "sub")).to eq(['"Test Group"'])
+          secret = subject.read("secret", key)
+          expect(secret).to be
+          expect(secret.data).to eq(foo:"bar")
+        end
       end
 
-      it "allows special characters" do
-        subject.write("secret", "b:@c%n-delete", foo: "bar")
-        expect(subject.delete("secret", "b:@c%n-delete")).to be(true)
-        expect(subject.read("secret", "b:@c%n-delete")).to be(nil)
+      describe "#delete" do
+        it "deletes the secret" do
+          subject.write("secret", "delete", foo: "bar")
+          expect(subject.delete("secret", "delete")).to be(true)
+          expect(subject.read("secret", "delete")).to be(nil)
+        end
+
+        it "allows special characters" do
+          subject.write("secret", "b:@c%n-delete", foo: "bar")
+          expect(subject.delete("secret", "b:@c%n-delete")).to be(true)
+          expect(subject.read("secret", "b:@c%n-delete")).to be(nil)
+        end
+
+        it "does not error if the secret does not exist" do
+          expect {
+            subject.delete("secret", "delete")
+            subject.delete("secret", "delete")
+            subject.delete("secret", "delete")
+          }.to_not raise_error
+        end
       end
 
-      it "does not error if the secret does not exist" do
-        expect {
-          subject.delete("secret", "delete")
-          subject.delete("secret", "delete")
-          subject.delete("secret", "delete")
-        }.to_not raise_error
+      describe "#unwrap", vault: ">= 0.6" do
+        it "returns the wrapped secret when it exists" do
+          wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
+          unwrapped = subject.unwrap(wrapped.wrap_info.token)
+
+          expect(unwrapped.auth).to be
+          expect(unwrapped.auth.client_token).to be
+
+          vault_test_client.with_token(unwrapped.auth.client_token) do |client|
+            expect { client.logical(:versioned).read("secret", "test") }.to_not raise_error
+          end
+        end
       end
-    end
 
-    describe "#unwrap", vault: ">= 0.6" do
-      it "returns the wrapped secret when it exists" do
-        wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
-        unwrapped = subject.unwrap(wrapped.wrap_info.token)
+      describe "#unwrap_token", vault: ">= 0.6" do
+        it "returns the wrapped token when given a string" do
+          wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
+          unwrapped = subject.unwrap_token(wrapped.wrap_info.token)
 
-        expect(unwrapped.auth).to be
-        expect(unwrapped.auth.client_token).to be
+          expect(unwrapped).to be
 
-        vault_test_client.with_token(unwrapped.auth.client_token) do |client|
-          expect { client.logical2.read("secret", "test") }.to_not raise_error
+          vault_test_client.with_token(unwrapped) do |client|
+            expect { client.logical(:versioned).read("secret", "test") }.to_not raise_error
+          end
+        end
+
+        it "returns the wrapped token when given a Vault::Secret" do
+          wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
+          unwrapped = subject.unwrap_token(wrapped)
+
+          expect(unwrapped).to be
+
+          vault_test_client.with_token(unwrapped) do |client|
+            expect { client.logical(:versioned).read("secret", "test") }.to_not raise_error
+          end
+        end
+
+        it "returns nil when the response is empty" do
+          token = vault_test_client.auth_token.create # Note no wrap-ttl here
+          unwrapped = subject.unwrap_token(token.auth.client_token)
+          expect(unwrapped).to be(nil)
         end
       end
     end
 
-    describe "#unwrap_token", vault: ">= 0.6" do
-      it "returns the wrapped token when given a string" do
-        wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
-        unwrapped = subject.unwrap_token(wrapped.wrap_info.token)
+    describe Unversioned do
+      subject { vault_test_client.logical(:unversioned) }
 
-        expect(unwrapped).to be
+      before(:context) do
+        vault_test_client.sys.mount("legacy-secret", "kv", "", version: 1)
+      end
 
-        vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical2.read("secret", "test") }.to_not raise_error
+      after(:context) do
+        vault_test_client.sys.unmount("legacy-secret")
+      end
+
+      describe "#list" do
+        it "returns the empty array when no items exist" do
+          expect(subject.list("legacy-secret/that/never/existed")).to eq([])
+        end
+
+        it "returns all secrets" do
+          subject.write("legacy-secret/test-list-1", foo: "bar")
+          subject.write("legacy-secret/test-list-2", foo: "bar")
+          secrets = subject.list("legacy-secret")
+          expect(secrets).to be_a(Array)
+          expect(secrets).to include("test-list-1")
+          expect(secrets).to include("test-list-2")
         end
       end
 
-      it "returns the wrapped token when given a Vault::Secret" do
-        wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
-        unwrapped = subject.unwrap_token(wrapped)
+      describe "#read" do
+        it "returns nil with the thing does not exist" do
+          expect(subject.read("legacy-secret/foo/bar/zip")).to be(nil)
+        end
 
-        expect(unwrapped).to be
+        it "returns the secret when it exists" do
+          subject.write("legacy-secret/test-read", foo: "bar")
+          secret = subject.read("legacy-secret/test-read")
+          expect(secret).to be
+          expect(secret.data).to eq(foo: "bar")
+        end
 
-        vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical2.read("secret", "test") }.to_not raise_error
+        it "allows special characters" do
+          subject.write("legacy-secret/b:@c%n-read", foo: "bar")
+          secret = subject.read("legacy-secret/b:@c%n-read")
+          expect(secret).to be
+          expect(secret.data).to eq(foo: "bar")
         end
       end
 
-      it "returns nil when the response is empty" do
-        token = vault_test_client.auth_token.create # Note no wrap-ttl here
-        unwrapped = subject.unwrap_token(token.auth.client_token)
-        expect(unwrapped).to be(nil)
-      end
-    end
-  end
-
-  describe Logical do
-    subject { vault_test_client.logical }
-
-    before(:context) do
-      vault_test_client.sys.mount("legacy-secret", "kv", "", version: 1)
-    end
-
-    after(:context) do
-      vault_test_client.sys.unmount("legacy-secret")
-    end
-
-    describe "#list" do
-      it "returns the empty array when no items exist" do
-        expect(subject.list("legacy-secret/that/never/existed")).to eq([])
-      end
-
-      it "returns all secrets" do
-        subject.write("legacy-secret/test-list-1", foo: "bar")
-        subject.write("legacy-secret/test-list-2", foo: "bar")
-        secrets = subject.list("legacy-secret")
-        expect(secrets).to be_a(Array)
-        expect(secrets).to include("test-list-1")
-        expect(secrets).to include("test-list-2")
-      end
-    end
-
-    describe "#read" do
-      it "returns nil with the thing does not exist" do
-        expect(subject.read("legacy-secret/foo/bar/zip")).to be(nil)
-      end
-
-      it "returns the secret when it exists" do
-        subject.write("legacy-secret/test-read", foo: "bar")
-        secret = subject.read("legacy-secret/test-read")
-        expect(secret).to be
-        expect(secret.data).to eq(foo: "bar")
-      end
-
-      it "allows special characters" do
-        subject.write("legacy-secret/b:@c%n-read", foo: "bar")
-        secret = subject.read("legacy-secret/b:@c%n-read")
-        expect(secret).to be
-        expect(secret.data).to eq(foo: "bar")
-      end
-    end
-
-    describe "#write" do
-      it "creates and returns the secret" do
-        subject.write("legacy-secret/test-write", zip: "zap")
-        result = subject.read("legacy-secret/test-write")
-        expect(result).to be
-        expect(result.data).to eq(zip: "zap")
-      end
-
-      it "overwrites existing secrets" do
-        subject.write("legacy-secret/test-overwrite", zip: "zap")
-        subject.write("legacy-secret/test-overwrite", bacon: true)
-        result = subject.read("legacy-secret/test-overwrite")
-        expect(result).to be
-        expect(result.data).to eq(bacon: true)
-      end
-
-      it "allows special characters" do
-        subject.write("legacy-secret/b:@c%n-write", foo: "bar")
-        subject.write("legacy-secret/b:@c%n-write", bacon: true)
-        secret = subject.read("legacy-secret/b:@c%n-write")
-        expect(secret).to be
-        expect(secret.data).to eq(bacon: true)
-      end
-
-      it "respects spaces properly" do
-        key = 'legacy-secret/sub/"Test Group"'
-        subject.write(key, foo: "bar")
-        expect(subject.list("legacy-secret/sub")).to eq(['"Test Group"'])
-        secret = subject.read(key)
-        expect(secret).to be
-        expect(secret.data).to eq(foo:"bar")
-      end
-    end
-
-    describe "#delete" do
-      it "deletes the secret" do
-        subject.write("legacy-secret/delete", foo: "bar")
-        expect(subject.delete("legacy-secret/delete")).to be(true)
-        expect(subject.read("legacy-secret/delete")).to be(nil)
-      end
-
-      it "allows special characters" do
-        subject.write("legacy-secret/b:@c%n-delete", foo: "bar")
-        expect(subject.delete("legacy-secret/b:@c%n-delete")).to be(true)
-        expect(subject.read("legacy-secret/b:@c%n-delete")).to be(nil)
-      end
-
-      it "does not error if the secret does not exist" do
-        expect {
-          subject.delete("legacy-secret/delete")
-          subject.delete("legacy-secret/delete")
-          subject.delete("legacy-secret/delete")
-        }.to_not raise_error
-      end
-    end
-
-    describe "#unwrap", vault: ">= 0.6" do
-      it "returns the wrapped secret when it exists" do
-        wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
-        unwrapped = subject.unwrap(wrapped.wrap_info.token)
-
-        expect(unwrapped.auth).to be
-        expect(unwrapped.auth.client_token).to be
-
-        vault_test_client.with_token(unwrapped.auth.client_token) do |client|
-          expect { client.logical.read("legacy-secret/test") }.to_not raise_error
+      describe "#write" do
+        it "creates and returns the secret" do
+          subject.write("legacy-secret/test-write", zip: "zap")
+          result = subject.read("legacy-secret/test-write")
+          expect(result).to be
+          expect(result.data).to eq(zip: "zap")
         end
-      end
-    end
 
-    describe "#unwrap_token", vault: ">= 0.6" do
-      it "returns the wrapped token when given a string" do
-        wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
-        unwrapped = subject.unwrap_token(wrapped.wrap_info.token)
+        it "overwrites existing secrets" do
+          subject.write("legacy-secret/test-overwrite", zip: "zap")
+          subject.write("legacy-secret/test-overwrite", bacon: true)
+          result = subject.read("legacy-secret/test-overwrite")
+          expect(result).to be
+          expect(result.data).to eq(bacon: true)
+        end
 
-        expect(unwrapped).to be
+        it "allows special characters" do
+          subject.write("legacy-secret/b:@c%n-write", foo: "bar")
+          subject.write("legacy-secret/b:@c%n-write", bacon: true)
+          secret = subject.read("legacy-secret/b:@c%n-write")
+          expect(secret).to be
+          expect(secret.data).to eq(bacon: true)
+        end
 
-        vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical.read("legacy-secret/test") }.to_not raise_error
+        it "respects spaces properly" do
+          key = 'legacy-secret/sub/"Test Group"'
+          subject.write(key, foo: "bar")
+          expect(subject.list("legacy-secret/sub")).to eq(['"Test Group"'])
+          secret = subject.read(key)
+          expect(secret).to be
+          expect(secret.data).to eq(foo:"bar")
         end
       end
 
-      it "returns the wrapped token when given a Vault::Secret" do
-        wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
-        unwrapped = subject.unwrap_token(wrapped)
+      describe "#delete" do
+        it "deletes the secret" do
+          subject.write("legacy-secret/delete", foo: "bar")
+          expect(subject.delete("legacy-secret/delete")).to be(true)
+          expect(subject.read("legacy-secret/delete")).to be(nil)
+        end
 
-        expect(unwrapped).to be
+        it "allows special characters" do
+          subject.write("legacy-secret/b:@c%n-delete", foo: "bar")
+          expect(subject.delete("legacy-secret/b:@c%n-delete")).to be(true)
+          expect(subject.read("legacy-secret/b:@c%n-delete")).to be(nil)
+        end
 
-        vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical.read("legacy-secret/test") }.to_not raise_error
+        it "does not error if the secret does not exist" do
+          expect {
+            subject.delete("legacy-secret/delete")
+            subject.delete("legacy-secret/delete")
+            subject.delete("legacy-secret/delete")
+          }.to_not raise_error
         end
       end
 
-      it "returns nil when the response is empty" do
-        token = vault_test_client.auth_token.create # Note no wrap-ttl here
-        unwrapped = subject.unwrap_token(token.auth.client_token)
-        expect(unwrapped).to be(nil)
+      describe "#unwrap", vault: ">= 0.6" do
+        it "returns the wrapped secret when it exists" do
+          wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
+          unwrapped = subject.unwrap(wrapped.wrap_info.token)
+
+          expect(unwrapped.auth).to be
+          expect(unwrapped.auth.client_token).to be
+
+          vault_test_client.with_token(unwrapped.auth.client_token) do |client|
+            expect { client.logical.read("legacy-secret/test") }.to_not raise_error
+          end
+        end
+      end
+
+      describe "#unwrap_token", vault: ">= 0.6" do
+        it "returns the wrapped token when given a string" do
+          wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
+          unwrapped = subject.unwrap_token(wrapped.wrap_info.token)
+
+          expect(unwrapped).to be
+
+          vault_test_client.with_token(unwrapped) do |client|
+            expect { client.logical.read("legacy-secret/test") }.to_not raise_error
+          end
+        end
+
+        it "returns the wrapped token when given a Vault::Secret" do
+          wrapped = vault_test_client.auth_token.create(wrap_ttl: "5s")
+          unwrapped = subject.unwrap_token(wrapped)
+
+          expect(unwrapped).to be
+
+          vault_test_client.with_token(unwrapped) do |client|
+            expect { client.logical.read("legacy-secret/test") }.to_not raise_error
+          end
+        end
+
+        it "returns nil when the response is empty" do
+          token = vault_test_client.auth_token.create # Note no wrap-ttl here
+          unwrapped = subject.unwrap_token(token.auth.client_token)
+          expect(unwrapped).to be(nil)
+        end
       end
     end
   end

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -38,6 +38,13 @@ module Vault
           expect(secret).to be
           expect(secret.data).to eq(foo: "bar")
         end
+
+        it "returns the secret metadata" do
+          subject.write("secret", "b:@c%n-read", foo: "bar")
+          secret = subject.read("secret", "b:@c%n-read")
+          expect(secret).to be
+          expect(secret.metadata.keys).to match_array([:created_time, :deletion_time, :version, :destroyed])
+        end
       end
 
       describe "#write" do

--- a/spec/integration/redirection_spec.rb
+++ b/spec/integration/redirection_spec.rb
@@ -17,14 +17,14 @@ module Vault
       end
 
       it "handles redirections properly in PUT requests" do
-        redirected_client.put("/v1/secret/redirect", { works: true }.to_json)
-        expect(vault_test_client.logical.read('secret/redirect').data[:works]).to eq(true)
+        redirected_client.post("/v1/secret/data/redirect", { data: { works: true } }.to_json)
+        expect(vault_test_client.versioned_logical.read('secret', 'redirect').data[:works]).to eq(true)
       end
 
       it "handles redirections properly in DELETE requests" do
-        vault_test_client.logical.write('secret/redirect', { deleted: false })
-        redirected_client.delete("/v1/secret/redirect")
-        expect(vault_test_client.logical.read('secret/redirect')).to be_nil
+        vault_test_client.versioned_logical.write('secret', 'redirect', { deleted: false })
+        redirected_client.delete("/v1/secret/data/redirect")
+        expect(vault_test_client.versioned_logical.read('secret', 'redirect')).to be_nil
       end
 
       it "handles redirections properly in POST requests" do

--- a/spec/integration/redirection_spec.rb
+++ b/spec/integration/redirection_spec.rb
@@ -18,13 +18,13 @@ module Vault
 
       it "handles redirections properly in PUT requests" do
         redirected_client.post("/v1/secret/data/redirect", { data: { works: true } }.to_json)
-        expect(vault_test_client.versioned_logical.read('secret', 'redirect').data[:works]).to eq(true)
+        expect(vault_test_client.logical(:versioned).read('secret', 'redirect').data[:works]).to eq(true)
       end
 
       it "handles redirections properly in DELETE requests" do
-        vault_test_client.versioned_logical.write('secret', 'redirect', { deleted: false })
+        vault_test_client.logical(:versioned).write('secret', 'redirect', { deleted: false })
         redirected_client.delete("/v1/secret/data/redirect")
-        expect(vault_test_client.versioned_logical.read('secret', 'redirect')).to be_nil
+        expect(vault_test_client.logical(:versioned).read('secret', 'redirect')).to be_nil
       end
 
       it "handles redirections properly in POST requests" do

--- a/spec/support/redirect_server.rb
+++ b/spec/support/redirect_server.rb
@@ -9,13 +9,13 @@ module RSpec
     end
 
     def self.address
-      'http://127.0.0.1:8201/'
+      'http://127.0.0.1:8202/'
     end
 
     def self.start
       @server ||= begin
                     server = WEBrick::HTTPServer.new(
-                      Port: 8201,
+                      Port: 8202,
                       Logger: WEBrick::Log.new("/dev/null"),
                       AccessLogs: [],
                     )


### PR DESCRIPTION
This code could indeed be improved, and I'm pondering whether there's a way to have a single logical interface that handles both approaches, but here's what I've got for the moment:

```ruby
# Where /secret is a v1 KV secrets store (the existing behaviour):
client.logical(:unversioned).write("secret/bacon")
# Calling `logical` without an approach currently goes with the legacy (unversioned):
client.logical.write("secret/bacon")

# Where /secret is a v2 KV secrets store:
# The first argument gets split into two:
#   the mounted store path
#   the path of the secret in question
client.logical(:versioned).write("secret", "bacon")
# So, all operations via the versioned approach have this split-argument approach.
```

Tests pass on Vault v0.5 through to 0.11 🎉 

I feel like something smarter may mean introspection about the secret store versions, and that's perhaps not ideal? It's certainly extra overhead, albeit something that could be cached (but the extra smarts mean extra support challenges). My approach does allow for eventually making `:versioned` as the default when no argument is provided to `logical`, so at least that could be a viable deprecation/change moving forward in gem versions.

Would a retry-fallback be viable maybe? Attempt v2/versioned, and if that doesn't work, try v1/unversioned? Though `/data/` in-between the mount point and the secret names does make that messy (or even impossible?)