### PR TITLE
Added mount accessor to Auth response type

### DIFF
--- a/lib/vault/api/sys/auth.rb
+++ b/lib/vault/api/sys/auth.rb
@@ -11,6 +11,11 @@ module Vault
     #   Name of the auth backend.
     #   @return [String]
     field :type
+
+    # @!attribute [r] accessor
+    #   Mount accessor for auth backend.
+    #   @return [String]
+    field :accessor
   end
 
   class AuthConfig < Response


### PR DESCRIPTION
`Vault::Sys.auths` only returns `type` and `description` for each auth method.  However, the auth method `accessor` is required to create an entity alias.  Therefore, it makes it difficult to programmatically create aliases without having that attribute.  This adds the `accessor` attribute to the `Auth` response type.