### PR TITLE
Adding a separate interface for versioned KV secrets.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ language: ruby
 cache: bundler
 
 env:
+  - VAULT_VERSION=0.11.4
+  - VAULT_VERSION=0.10.4
+  - VAULT_VERSION=0.9.6
   - VAULT_VERSION=0.8.3
   - VAULT_VERSION=0.7.3
   - VAULT_VERSION=0.6.5

--- a/lib/vault/api.rb
+++ b/lib/vault/api.rb
@@ -5,6 +5,7 @@ module Vault
     require_relative "api/auth_tls"
     require_relative "api/auth"
     require_relative "api/help"
+    require_relative "api/kv"
     require_relative "api/logical"
     require_relative "api/secret"
     require_relative "api/sys"

--- a/lib/vault/api/kv.rb
+++ b/lib/vault/api/kv.rb
@@ -1,0 +1,207 @@
+require_relative "secret"
+require_relative "../client"
+require_relative "../request"
+require_relative "../response"
+
+module Vault
+  class Client
+    # A proxy to the {KV} methods.
+    # @return [KV]
+    def kv(mount)
+      KV.new(self, mount)
+    end
+  end
+
+  class KV < Request
+    attr_reader :mount
+
+    def initialize(client, mount)
+      super client
+
+      @mount = mount
+    end
+
+    # List the names of secrets at the given path, if the path supports
+    # listing. If the the path does not exist, an empty array will be returned.
+    #
+    # @example
+    #   Vault.kv("secret").list("foo") #=> ["bar", "baz"]
+    #
+    # @param [String] path
+    #   the path to list
+    #
+    # @return [Array<String>]
+    def list(path = "", options = {})
+      headers = extract_headers!(options)
+      json = client.list("/v1/#{mount}/metadata/#{encode_path(path)}", {}, headers)
+      json[:data][:keys] || []
+    rescue HTTPError => e
+      return [] if e.code == 404
+      raise
+    end
+
+    # Read the secret at the given path. If the secret does not exist, +nil+
+    # will be returned. The latest version is returned by default, but you
+    # can request a specific version.
+    #
+    # @example
+    #   Vault.kv("secret").read("password") #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] path
+    #   the path to read
+    # @param [Integer] version
+    #   the version of the secret
+    #
+    # @return [Secret, nil]
+    def read(path, version = nil, options = {})
+      headers = extract_headers!(options)
+      params  = {}
+      params[:version] = version unless version.nil?
+
+      json = client.get("/v1/#{mount}/data/#{encode_path(path)}", params, headers)
+      return Secret.decode(json[:data])
+    rescue HTTPError => e
+      return nil if e.code == 404
+      raise
+    end
+
+    # Read the metadata of a secret at the given path. If the secret does not
+    # exist, nil will be returned.
+    #
+    # @example
+    #    Vault.kv("secret").read_metadata("password") => {...}
+    #
+    # @param [String] path
+    #   the path to read
+    #
+    # @return [Hash, nil]
+    def read_metadata(path)
+      client.get("/v1/#{mount}/metadata/#{encode_path(path)}")[:data]
+    rescue HTTPError => e
+      return nil if e.code == 404
+      raise
+    end
+
+    # Write the secret at the given path with the given data. Note that the
+    # data must be a {Hash}!
+    #
+    # @example
+    #   Vault.logical.write("secret/password", value: "secret") #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] path
+    #   the path to write
+    # @param [Hash] data
+    #   the data to write
+    #
+    # @return [Secret]
+    def write(path, data = {}, options = {})
+      headers = extract_headers!(options)
+      json = client.post("/v1/#{mount}/data/#{encode_path(path)}", JSON.fast_generate(:data => data), headers)
+      if json.nil?
+        return true
+      else
+        return Secret.decode(json)
+      end
+    end
+
+    # Write the metadata of a secret at the given path. Note that teh data must
+    # be a {Hash}.
+    #
+    # @example
+    #    Vault.kv("secret").write_metadata("password", max_versions => 3)
+    #
+    # @param [String] path
+    #   the path to write
+    # @param [Hash] metadata
+    #    the metadata to write
+    #
+    # @return [true]
+    def write_metadata(path, metadata = {})
+      client.post("/v1/#{mount}/metadata/#{encode_path(path)}", JSON.fast_generate(metadata))
+
+      true
+    end
+
+    # Delete the secret at the given path. If the secret does not exist, vault
+    # will still return true.
+    #
+    # @example
+    #   Vault.logical.delete("secret/password") #=> true
+    #
+    # @param [String] path
+    #   the path to delete
+    #
+    # @return [true]
+    def delete(path)
+      client.delete("/v1/#{mount}/data/#{encode_path(path)}")
+
+      true
+    end
+
+    # Mark specific versions of a secret as deleted.
+    #
+    # @example
+    #   Vault.kv("secret").delete_versions("password", [1, 2])
+    #
+    # @param [String] path
+    #   the path to remove versions from
+    # @param [Array<Integer>] versions
+    #   an array of versions to remove
+    #
+    # @return [true]
+    def delete_versions(path, versions)
+      client.post("/v1/#{mount}/delete/#{encode_path(path)}", JSON.fast_generate(versions: versions))
+
+      true
+    end
+
+    # Mark specific versions of a secret as active.
+    #
+    # @example
+    #   Vault.kv("secret").undelete_versions("password", [1, 2])
+    #
+    # @param [String] path
+    #   the path to enable versions for
+    # @param [Array<Integer>] versions
+    #   an array of versions to mark as undeleted
+    #
+    # @return [true]
+    def undelete_versions(path, versions)
+      client.post("/v1/#{mount}/undelete/#{encode_path(path)}", JSON.fast_generate(versions: versions))
+
+      true
+    end
+
+    # Completely remove a secret and its metadata.
+    #
+    # @example
+    #   Vault.kv("secret").destroy("password")
+    #
+    # @param [String] path
+    #   the path to remove
+    #
+    # @return [true]
+    def destroy(path)
+      client.delete("/v1/#{mount}/metadata/#{encode_path(path)}")
+
+      true
+    end
+
+    # Completely remove specific versions of a secret.
+    #
+    # @example
+    #   Vault.kv("secret").destroy_versions("password", [1, 2])
+    #
+    # @param [String] path
+    #   the path to remove versions from
+    # @param [Array<Integer>] versions
+    #   an array of versions to destroy
+    #
+    # @return [true]
+    def destroy_versions(path, versions)
+      client.post("/v1/#{mount}/destroy/#{encode_path(path)}", JSON.fast_generate(versions: versions))
+
+      true
+    end
+  end
+end

--- a/lib/vault/api/secret.rb
+++ b/lib/vault/api/secret.rb
@@ -32,6 +32,18 @@ module Vault
     #   @return [Hash<Symbol, Object>]
     field :data, freeze: true
 
+    # @!attribute [r] metadata
+    #   Read-only metadata information related to the secret.
+    #
+    #   @example Reading metadata
+    #     secret = Vault.logical(:versioned).read("secret", "foo")
+    #     secret.metadata[:created_time] #=> "2018-12-08T04:22:54.168065Z"
+    #     secret.metadata[:version]      #=> 1
+    #     secret.metadata[:destroyed]    #=> false
+    #
+    #   @return [Hash<Symbol, Object>]
+    field :metadata, freeze: true
+
     # @!attribute [r] lease_duration
     #   The number of seconds this lease is valid. If this number is 0 or nil,
     #   the secret does not expire.

--- a/lib/vault/api/sys/mount.rb
+++ b/lib/vault/api/sys/mount.rb
@@ -44,8 +44,8 @@ module Vault
     #   the type of mount
     # @param [String] description
     #   a human-friendly description (optional)
-    def mount(path, type, description = nil)
-      payload = { type: type }
+    def mount(path, type, description = nil, options = {})
+      payload = options.merge type: type
       payload[:description] = description if !description.nil?
 
       client.post("/v1/sys/mounts/#{encode_path(path)}", JSON.fast_generate(payload))

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -261,6 +261,8 @@ module Vault
 
     describe "#gcp", vault: ">= 0.8.1" do
       before(:context) do
+        skip "gcp auth requires real resources and keys"
+
         vault_test_client.sys.enable_auth("gcp", "gcp", nil)
         vault_test_client.post("/v1/auth/gcp/config", JSON.fast_generate("service_account" => "rspec_service_account"))
         vault_test_client.post("/v1/auth/gcp/role/rspec_wrong_role", JSON.fast_generate("name" => "rspec_role", "project_id" => "wrong_project_id", "bound_service_accounts" => "\*", "type" => "iam"))

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -244,7 +244,7 @@ module Vault
         )
         expect do
           subject.auth.aws_iam('a_rolename', credentials_provider, 'mismatched_iam_header', 'https://sts.cn-north-1.amazonaws.com.cn') 
-        end.to raise_error(Vault::HTTPClientError, /expected iam_header_canary but got mismatched_iam_header/)
+        end.to raise_error(Vault::HTTPClientError, /expected "?iam_header_canary"? but got "?mismatched_iam_header"?/)
       end
 
       it "authenticates and saves the token on the client" do

--- a/spec/integration/api/kv_spec.rb
+++ b/spec/integration/api/kv_spec.rb
@@ -55,6 +55,13 @@ module Vault
         secret = subject.read("test", 1)
         expect(secret.data).to eq(foo: "bar")
       end
+
+      it "returns the secret metadata" do
+        subject.write("b:@c%n-read", foo: "bar")
+        secret = subject.read("b:@c%n-read")
+        expect(secret).to be
+        expect(secret.metadata.keys).to match_array([:created_time, :deletion_time, :version, :destroyed])
+      end
     end
 
     describe "#read_metadata" do

--- a/spec/integration/api/kv_spec.rb
+++ b/spec/integration/api/kv_spec.rb
@@ -1,0 +1,189 @@
+require "spec_helper"
+
+module Vault
+  describe KV, vault: ">= 0.10" do
+    subject { vault_test_client.kv("versioned-kv") }
+
+    before(:context) do
+      vault_test_client.sys.mount(
+        "versioned-kv", "kv", "v2 KV", options: {version: "2"}
+      )
+    end
+
+    after(:context) do
+      vault_test_client.sys.unmount("versioned-kv")
+    end
+
+    describe "#list" do
+      it "returns the empty array when no items exist" do
+        expect(subject.list("secrets/that/never/existed")).to eq([])
+      end
+
+      it "returns all secrets" do
+        subject.write("secrets/test-list-1", foo: "bar")
+        subject.write("secrets/test-list-2", foo: "bar")
+        secrets = subject.list("secrets")
+
+        expect(secrets).to be_a(Array)
+        expect(secrets).to include("test-list-1")
+        expect(secrets).to include("test-list-2")
+      end
+    end
+
+    describe "#read" do
+      it "returns nil with the thing does not exist" do
+        expect(subject.read("foo/bar/zip")).to be(nil)
+      end
+
+      it "returns the secret when it exists" do
+        subject.write("test-read", foo: "bar")
+        secret = subject.read("test-read")
+        expect(secret).to be
+        expect(secret.data).to eq(foo: "bar")
+      end
+
+      it "allows special characters" do
+        subject.write("b:@c%n-read", foo: "bar")
+        secret = subject.read("b:@c%n-read")
+        expect(secret).to be
+        expect(secret.data).to eq(foo: "bar")
+      end
+
+      it "allows reading of old versions" do
+        subject.write("test", foo: "bar")
+        subject.write("test", foo: "baz")
+        secret = subject.read("test", 1)
+        expect(secret.data).to eq(foo: "bar")
+      end
+    end
+
+    describe "#read_metadata" do
+      it "returns nil if the thing does not exist" do
+        expect(subject.read_metadata("foo/bar/zip")).to be(nil)
+      end
+
+      it "returns the metadata when it exists" do
+        subject.write("test-read", foo: "bar")
+        expect(subject.read_metadata("test-read")).to be_a(Hash)
+      end
+    end
+
+    describe "#write" do
+      it "creates and returns the secret" do
+        subject.write("test-write", zip: "zap")
+        result = subject.read("test-write")
+        expect(result).to be
+        expect(result.data).to eq(zip: "zap")
+      end
+
+      it "overwrites existing secrets" do
+        subject.write("test-overwrite", zip: "zap")
+        subject.write("test-overwrite", bacon: true)
+        result = subject.read("test-overwrite")
+        expect(result).to be
+        expect(result.data).to eq(bacon: true)
+      end
+
+      it "allows special characters" do
+        subject.write("b:@c%n-write", foo: "bar")
+        subject.write("b:@c%n-write", bacon: true)
+        secret = subject.read("b:@c%n-write")
+        expect(secret).to be
+        expect(secret.data).to eq(bacon: true)
+      end
+
+      it "respects spaces properly" do
+        key = 'sub/"Test Group"'
+        subject.write(key, foo: "bar")
+        expect(subject.list("sub")).to eq(['"Test Group"'])
+        secret = subject.read(key)
+        expect(secret).to be
+        expect(secret.data).to eq(foo:"bar")
+      end
+    end
+
+    describe "#write_metadata" do
+      it "updates metadata for the secret" do
+        subject.write("test-meta", zip: "zap")
+        expect(subject.read_metadata("test-meta")[:max_versions]).to eq(0)
+        subject.write_metadata("test-meta", max_versions: 3)
+        expect(subject.read_metadata("test-meta")[:max_versions]).to eq(3)
+      end
+    end
+
+    describe "#delete" do
+      it "deletes the secret" do
+        subject.write("delete", foo: "bar")
+        expect(subject.delete("delete")).to be(true)
+        expect(subject.read("delete")).to be(nil)
+      end
+
+      it "allows special characters" do
+        subject.write("b:@c%n-delete", foo: "bar")
+        expect(subject.delete("b:@c%n-delete")).to be(true)
+        expect(subject.read("b:@c%n-delete")).to be(nil)
+      end
+
+      it "does not error if the secret does not exist" do
+        expect {
+          subject.delete("delete")
+          subject.delete("delete")
+          subject.delete("delete")
+        }.to_not raise_error
+      end
+    end
+
+    describe "#delete_versions" do
+      it "can remove specific versions" do
+        subject.write("delete-old", foo: "bar")
+        subject.write("delete-old", foo: "baz")
+        subject.delete_versions("delete-old", [1])
+        expect(subject.read("delete-old", 1)).to be_nil
+      end
+
+      it "still has the versions in the history" do
+        subject.write("delete-older", foo: "bar")
+        subject.write("delete-older", foo: "baz")
+        subject.delete_versions("delete-older", [1])
+        expect(subject.read_metadata("delete-older")[:versions][:"1"]).to be
+      end
+    end
+
+    describe "#undelete_versions" do
+      it "restores a secret" do
+        subject.write("mistake", foo: "bar")
+        subject.delete("mistake")
+        expect(subject.read("mistake")).to be(nil)
+        subject.undelete_versions("mistake", [1])
+        expect(subject.read("mistake").data).to eq(foo: "bar")
+      end
+    end
+
+    describe "#destroy" do
+      it "removes everything" do
+        subject.write("destroy", foo: "bar")
+        subject.write("destroy", foo: "baz")
+        subject.destroy("destroy")
+        expect(subject.read("destroy")).to be_nil
+        expect(subject.read_metadata("destroy")).to be_nil
+      end
+    end
+
+    describe "#destroy_versions" do
+      it "can remove specific versions" do
+        subject.write("destroy-old", foo: "bar")
+        subject.write("destroy-old", foo: "baz")
+        subject.destroy_versions("delete-old", [1])
+        expect(subject.read("delete-old", 1)).to be_nil
+      end
+
+      it "ensures versions can't be restored" do
+        subject.write("destroy-older", foo: "bar")
+        subject.write("destroy-older", foo: "baz")
+        subject.destroy_versions("destroy-older", [1])
+        subject.undelete_versions("destroy-older", [1])
+        expect(subject.read("destroy-older", 1)).to be_nil
+      end
+    end
+  end
+end

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -5,24 +5,32 @@ module Vault
     subject { vault_test_client.logical }
 
     before(:context) do
+      next unless versioned_kv_by_default?
+
+      vault_test_client.sys.unmount("secret")
       vault_test_client.sys.mount(
-        "unversioned", "kv", "v1 KV", options: {version: "1"}
+        "secret", "kv", "v1 KV", options: {version: "1"}
       )
     end
 
     after(:context) do
-      vault_test_client.sys.unmount("unversioned")
+      next unless versioned_kv_by_default?
+
+      vault_test_client.sys.unmount("secret")
+      vault_test_client.sys.mount(
+        "secret", "kv", "v2 KV", options: {version: "2"}
+      )
     end
 
     describe "#list" do
       it "returns the empty array when no items exist" do
-        expect(subject.list("unversioned/that/never/existed")).to eq([])
+        expect(subject.list("secret/that/never/existed")).to eq([])
       end
 
       it "returns all secrets" do
-        subject.write("unversioned/test-list-1", foo: "bar")
-        subject.write("unversioned/test-list-2", foo: "bar")
-        secrets = subject.list("unversioned")
+        subject.write("secret/test-list-1", foo: "bar")
+        subject.write("secret/test-list-2", foo: "bar")
+        secrets = subject.list("secret")
         expect(secrets).to be_a(Array)
         expect(secrets).to include("test-list-1")
         expect(secrets).to include("test-list-2")
@@ -31,19 +39,19 @@ module Vault
 
     describe "#read" do
       it "returns nil with the thing does not exist" do
-        expect(subject.read("unversioned/foo/bar/zip")).to be(nil)
+        expect(subject.read("secret/foo/bar/zip")).to be(nil)
       end
 
       it "returns the secret when it exists" do
-        subject.write("unversioned/test-read", foo: "bar")
-        secret = subject.read("unversioned/test-read")
+        subject.write("secret/test-read", foo: "bar")
+        secret = subject.read("secret/test-read")
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
 
       it "allows special characters" do
-        subject.write("unversioned/b:@c%n-read", foo: "bar")
-        secret = subject.read("unversioned/b:@c%n-read")
+        subject.write("secret/b:@c%n-read", foo: "bar")
+        secret = subject.read("secret/b:@c%n-read")
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
@@ -51,32 +59,32 @@ module Vault
 
     describe "#write" do
       it "creates and returns the secret" do
-        subject.write("unversioned/test-write", zip: "zap")
-        result = subject.read("unversioned/test-write")
+        subject.write("secret/test-write", zip: "zap")
+        result = subject.read("secret/test-write")
         expect(result).to be
         expect(result.data).to eq(zip: "zap")
       end
 
       it "overwrites existing secrets" do
-        subject.write("unversioned/test-overwrite", zip: "zap")
-        subject.write("unversioned/test-overwrite", bacon: true)
-        result = subject.read("unversioned/test-overwrite")
+        subject.write("secret/test-overwrite", zip: "zap")
+        subject.write("secret/test-overwrite", bacon: true)
+        result = subject.read("secret/test-overwrite")
         expect(result).to be
         expect(result.data).to eq(bacon: true)
       end
 
       it "allows special characters" do
-        subject.write("unversioned/b:@c%n-write", foo: "bar")
-        subject.write("unversioned/b:@c%n-write", bacon: true)
-        secret = subject.read("unversioned/b:@c%n-write")
+        subject.write("secret/b:@c%n-write", foo: "bar")
+        subject.write("secret/b:@c%n-write", bacon: true)
+        secret = subject.read("secret/b:@c%n-write")
         expect(secret).to be
         expect(secret.data).to eq(bacon: true)
       end
 
       it "respects spaces properly" do
-        key = 'unversioned/sub/"Test Group"'
+        key = 'secret/sub/"Test Group"'
         subject.write(key, foo: "bar")
-        expect(subject.list("unversioned/sub")).to eq(['"Test Group"'])
+        expect(subject.list("secret/sub")).to eq(['"Test Group"'])
         secret = subject.read(key)
         expect(secret).to be
         expect(secret.data).to eq(foo:"bar")
@@ -85,22 +93,22 @@ module Vault
 
     describe "#delete" do
       it "deletes the secret" do
-        subject.write("unversioned/delete", foo: "bar")
-        expect(subject.delete("unversioned/delete")).to be(true)
-        expect(subject.read("unversioned/delete")).to be(nil)
+        subject.write("secret/delete", foo: "bar")
+        expect(subject.delete("secret/delete")).to be(true)
+        expect(subject.read("secret/delete")).to be(nil)
       end
 
       it "allows special characters" do
-        subject.write("unversioned/b:@c%n-delete", foo: "bar")
-        expect(subject.delete("unversioned/b:@c%n-delete")).to be(true)
-        expect(subject.read("unversioned/b:@c%n-delete")).to be(nil)
+        subject.write("secret/b:@c%n-delete", foo: "bar")
+        expect(subject.delete("secret/b:@c%n-delete")).to be(true)
+        expect(subject.read("secret/b:@c%n-delete")).to be(nil)
       end
 
       it "does not error if the secret does not exist" do
         expect {
-          subject.delete("unversioned/delete")
-          subject.delete("unversioned/delete")
-          subject.delete("unversioned/delete")
+          subject.delete("secret/delete")
+          subject.delete("secret/delete")
+          subject.delete("secret/delete")
         }.to_not raise_error
       end
     end
@@ -114,7 +122,7 @@ module Vault
         expect(unwrapped.auth.client_token).to be
 
         vault_test_client.with_token(unwrapped.auth.client_token) do |client|
-          expect { client.logical.read("unversioned/test") }.to_not raise_error
+          expect { client.logical.read("secret/test") }.to_not raise_error
         end
       end
     end
@@ -127,7 +135,7 @@ module Vault
         expect(unwrapped).to be
 
         vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical.read("unversioned/test") }.to_not raise_error
+          expect { client.logical.read("secret/test") }.to_not raise_error
         end
       end
 
@@ -138,7 +146,7 @@ module Vault
         expect(unwrapped).to be
 
         vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical.read("unversioned/test") }.to_not raise_error
+          expect { client.logical.read("secret/test") }.to_not raise_error
         end
       end
 

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -4,15 +4,25 @@ module Vault
   describe Logical do
     subject { vault_test_client.logical }
 
+    before(:context) do
+      vault_test_client.sys.mount(
+        "unversioned", "kv", "v1 KV", options: {version: "1"}
+      )
+    end
+
+    after(:context) do
+      vault_test_client.sys.unmount("unversioned")
+    end
+
     describe "#list" do
       it "returns the empty array when no items exist" do
-        expect(subject.list("secret/that/never/existed")).to eq([])
+        expect(subject.list("unversioned/that/never/existed")).to eq([])
       end
 
       it "returns all secrets" do
-        subject.write("secret/test-list-1", foo: "bar")
-        subject.write("secret/test-list-2", foo: "bar")
-        secrets = subject.list("secret")
+        subject.write("unversioned/test-list-1", foo: "bar")
+        subject.write("unversioned/test-list-2", foo: "bar")
+        secrets = subject.list("unversioned")
         expect(secrets).to be_a(Array)
         expect(secrets).to include("test-list-1")
         expect(secrets).to include("test-list-2")
@@ -21,19 +31,19 @@ module Vault
 
     describe "#read" do
       it "returns nil with the thing does not exist" do
-        expect(subject.read("secret/foo/bar/zip")).to be(nil)
+        expect(subject.read("unversioned/foo/bar/zip")).to be(nil)
       end
 
       it "returns the secret when it exists" do
-        subject.write("secret/test-read", foo: "bar")
-        secret = subject.read("secret/test-read")
+        subject.write("unversioned/test-read", foo: "bar")
+        secret = subject.read("unversioned/test-read")
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-read", foo: "bar")
-        secret = subject.read("secret/b:@c%n-read")
+        subject.write("unversioned/b:@c%n-read", foo: "bar")
+        secret = subject.read("unversioned/b:@c%n-read")
         expect(secret).to be
         expect(secret.data).to eq(foo: "bar")
       end
@@ -41,32 +51,32 @@ module Vault
 
     describe "#write" do
       it "creates and returns the secret" do
-        subject.write("secret/test-write", zip: "zap")
-        result = subject.read("secret/test-write")
+        subject.write("unversioned/test-write", zip: "zap")
+        result = subject.read("unversioned/test-write")
         expect(result).to be
         expect(result.data).to eq(zip: "zap")
       end
 
       it "overwrites existing secrets" do
-        subject.write("secret/test-overwrite", zip: "zap")
-        subject.write("secret/test-overwrite", bacon: true)
-        result = subject.read("secret/test-overwrite")
+        subject.write("unversioned/test-overwrite", zip: "zap")
+        subject.write("unversioned/test-overwrite", bacon: true)
+        result = subject.read("unversioned/test-overwrite")
         expect(result).to be
         expect(result.data).to eq(bacon: true)
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-write", foo: "bar")
-        subject.write("secret/b:@c%n-write", bacon: true)
-        secret = subject.read("secret/b:@c%n-write")
+        subject.write("unversioned/b:@c%n-write", foo: "bar")
+        subject.write("unversioned/b:@c%n-write", bacon: true)
+        secret = subject.read("unversioned/b:@c%n-write")
         expect(secret).to be
         expect(secret.data).to eq(bacon: true)
       end
 
       it "respects spaces properly" do
-        key = 'secret/sub/"Test Group"'
+        key = 'unversioned/sub/"Test Group"'
         subject.write(key, foo: "bar")
-        expect(subject.list("secret/sub")).to eq(['"Test Group"'])
+        expect(subject.list("unversioned/sub")).to eq(['"Test Group"'])
         secret = subject.read(key)
         expect(secret).to be
         expect(secret.data).to eq(foo:"bar")
@@ -75,22 +85,22 @@ module Vault
 
     describe "#delete" do
       it "deletes the secret" do
-        subject.write("secret/delete", foo: "bar")
-        expect(subject.delete("secret/delete")).to be(true)
-        expect(subject.read("secret/delete")).to be(nil)
+        subject.write("unversioned/delete", foo: "bar")
+        expect(subject.delete("unversioned/delete")).to be(true)
+        expect(subject.read("unversioned/delete")).to be(nil)
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-delete", foo: "bar")
-        expect(subject.delete("secret/b:@c%n-delete")).to be(true)
-        expect(subject.read("secret/b:@c%n-delete")).to be(nil)
+        subject.write("unversioned/b:@c%n-delete", foo: "bar")
+        expect(subject.delete("unversioned/b:@c%n-delete")).to be(true)
+        expect(subject.read("unversioned/b:@c%n-delete")).to be(nil)
       end
 
       it "does not error if the secret does not exist" do
         expect {
-          subject.delete("secret/delete")
-          subject.delete("secret/delete")
-          subject.delete("secret/delete")
+          subject.delete("unversioned/delete")
+          subject.delete("unversioned/delete")
+          subject.delete("unversioned/delete")
         }.to_not raise_error
       end
     end
@@ -104,7 +114,7 @@ module Vault
         expect(unwrapped.auth.client_token).to be
 
         vault_test_client.with_token(unwrapped.auth.client_token) do |client|
-          expect { client.logical.read("secret/test") }.to_not raise_error
+          expect { client.logical.read("unversioned/test") }.to_not raise_error
         end
       end
     end
@@ -117,7 +127,7 @@ module Vault
         expect(unwrapped).to be
 
         vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical.read("secret/test") }.to_not raise_error
+          expect { client.logical.read("unversioned/test") }.to_not raise_error
         end
       end
 
@@ -128,7 +138,7 @@ module Vault
         expect(unwrapped).to be
 
         vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical.read("secret/test") }.to_not raise_error
+          expect { client.logical.read("unversioned/test") }.to_not raise_error
         end
       end
 

--- a/spec/integration/redirection_spec.rb
+++ b/spec/integration/redirection_spec.rb
@@ -2,7 +2,6 @@ require "spec_helper"
 
 module Vault
   describe Client do
-
     def redirected_client
       Vault::Client.new(address: RSpec::RedirectServer.address, token: RSpec::VaultServer.token)
     end
@@ -12,13 +11,21 @@ module Vault
     end
 
     before(:context) do
+      next unless versioned_kv_by_default?
+
+      vault_test_client.sys.unmount("secret")
       vault_test_client.sys.mount(
-        "redirection", "kv", "v1 KV", options: {version: "1"}
+        "secret", "kv", "v1 KV", options: {version: "1"}
       )
     end
 
     after(:context) do
-      vault_test_client.sys.unmount("redirection")
+      next unless versioned_kv_by_default?
+
+      vault_test_client.sys.unmount("secret")
+      vault_test_client.sys.mount(
+        "secret", "kv", "v2 KV", options: {version: "2"}
+      )
     end
 
     describe "#request" do
@@ -27,14 +34,14 @@ module Vault
       end
 
       it "handles redirections properly in PUT requests" do
-        redirected_client.put("/v1/redirection/redirect", { works: true }.to_json)
-        expect(vault_test_client.logical.read('redirection/redirect').data[:works]).to eq(true)
+        redirected_client.put("/v1/secret/redirect", { works: true }.to_json)
+        expect(vault_test_client.logical.read('secret/redirect').data[:works]).to eq(true)
       end
 
       it "handles redirections properly in DELETE requests" do
-        vault_test_client.logical.write('redirection/redirect', { deleted: false })
-        redirected_client.delete("/v1/redirection/redirect")
-        expect(vault_test_client.logical.read('redirection/redirect')).to be_nil
+        vault_test_client.logical.write('secret/redirect', { deleted: false })
+        redirected_client.delete("/v1/secret/redirect")
+        expect(vault_test_client.logical.read('secret/redirect')).to be_nil
       end
 
       it "handles redirections properly in POST requests" do

--- a/spec/integration/redirection_spec.rb
+++ b/spec/integration/redirection_spec.rb
@@ -11,20 +11,30 @@ module Vault
       RSpec::RedirectServer.start
     end
 
+    before(:context) do
+      vault_test_client.sys.mount(
+        "redirection", "kv", "v1 KV", options: {version: "1"}
+      )
+    end
+
+    after(:context) do
+      vault_test_client.sys.unmount("redirection")
+    end
+
     describe "#request" do
       it "handles redirections properly in GET requests" do
         expect(redirected_client.get("/v1/sys/policy")[:policies]).to include('root')
       end
 
       it "handles redirections properly in PUT requests" do
-        redirected_client.put("/v1/secret/redirect", { works: true }.to_json)
-        expect(vault_test_client.logical.read('secret/redirect').data[:works]).to eq(true)
+        redirected_client.put("/v1/redirection/redirect", { works: true }.to_json)
+        expect(vault_test_client.logical.read('redirection/redirect').data[:works]).to eq(true)
       end
 
       it "handles redirections properly in DELETE requests" do
-        vault_test_client.logical.write('secret/redirect', { deleted: false })
-        redirected_client.delete("/v1/secret/redirect")
-        expect(vault_test_client.logical.read('secret/redirect')).to be_nil
+        vault_test_client.logical.write('redirection/redirect', { deleted: false })
+        redirected_client.delete("/v1/redirection/redirect")
+        expect(vault_test_client.logical.read('redirection/redirect')).to be_nil
       end
 
       it "handles redirections properly in POST requests" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,10 @@ def vault_redirect_test_client
   )
 end
 
+def versioned_kv_by_default?
+  Gem::Requirement.new(">= 0.10").satisfied_by?(TEST_VAULT_VERSION)
+end
+
 def with_stubbed_env(env = {})
   old = ENV.to_hash
   env.each do |k,v|

--- a/spec/support/redirect_server.rb
+++ b/spec/support/redirect_server.rb
@@ -9,13 +9,13 @@ module RSpec
     end
 
     def self.address
-      'http://127.0.0.1:8201/'
+      'http://127.0.0.1:8202/'
     end
 
     def self.start
       @server ||= begin
                     server = WEBrick::HTTPServer.new(
-                      Port: 8201,
+                      Port: 8202,
                       Logger: WEBrick::Log.new("/dev/null"),
                       AccessLogs: [],
                     )


### PR DESCRIPTION
Instead of the approach in #188, this PR adds a separate interface for KV secrets (and thus the existing `logical` remains unaltered for broader use).

The standard approach is rather similar, except that the mount point is an argument in `kv`:

```ruby
Vault.kv("secret").write("passwords", foo: "bar")
Vault.kv("secret").read("passwords")
```

There are also new methods for reading and manipulating metadata and versions (including the distinction of marking versions as deleted, versus completely destroying them - as noted by @ragurney in #188).

Changes I've brought across from #188 are more generic, and get the test suite working across old and new Vault versions.