### PR TITLE
Accept params to pass specific version

### DIFF
--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -42,9 +42,9 @@ module Vault
     #   the path to read
     #
     # @return [Secret, nil]
-    def read(path, options = {})
+    def read(path, params = {}, options = {})
       headers = extract_headers!(options)
-      json = client.get("/v1/#{encode_path(path)}", {}, headers)
+      json = client.get("/v1/#{encode_path(path)}", params, headers)
       return Secret.decode(json)
     rescue HTTPError => e
       return nil if e.code == 404


### PR DESCRIPTION
There's a high chance that I'm missing something here. This is what I got while trying to figure out how to query for a specific version.

Now this does what I was expecting to get.
```
@client.logical.read(path, {version: 2})
```