### PR TITLE
Notify newcomers to the gem that the current examples use older version of a specific secrets engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Vault.sys.seal_status
 
 #### Create a Secret
 ```ruby
+# Note: the following is for writing to the KV version 1 secrets engine. If using other secrets engines (including KV version 2), please see documentation https://www.vaultproject.io/api/secret/index.html
 Vault.logical.write("secret/bacon", delicious: true, cooktime: "11")
 #=> #<Vault::Secret lease_id="">
 ```


### PR DESCRIPTION
# What 
Adds notes about current examples in README and which secrets engine it is meant for

# Why 
I'm a newcomer to Vault and when following the README I was slightly confused because the current examples (I believe) are for writing to a KV version 1 secrets engine. So I also included a link to Vault's secrets engines APIs so the next user can easily check how to write to the specific secrets engine they desire :)