### PR TITLE
Add Okta auth method

### DIFF
--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -267,6 +267,28 @@ module Vault
       return secret
     end
 
+    # Authenticate via the okta authentication method. If authentication
+    # is successful, the resulting token will be stored on the client and used
+    # for future requests.
+    #
+    # @example
+    #   Vault.auth.okta("sethvargo", "s3kr3t") #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] username
+    # @param [String] password
+    # @param [Hash] options
+    #   additional options to pass to the authentication call, such as a custom
+    #   mount point
+    #
+    # @return [Secret]
+    def okta(username, password, options = {})
+      payload = { password: password }.merge(options)
+      json = client.post("/v1/auth/okta/login/#{encode_path(username)}", JSON.fast_generate(payload))
+      secret = Secret.decode(json)
+      client.token = secret.auth.client_token
+      return secret
+    end
+
     # Authenticate via a TLS authentication method. If authentication is
     # successful, the resulting token will be stored on the client and used
     # for future requests.

--- a/spec/unit/auth_spec.rb
+++ b/spec/unit/auth_spec.rb
@@ -2,7 +2,17 @@ require "spec_helper"
 
 module Vault
   describe Authenticate do
-    let(:auth) { Authenticate.new(client: nil) }
+    let(:client) { double('client') }
+    let(:auth) { Authenticate.new(client) }
+
+    describe '#okta' do
+      it 'authenticates with Okta auth method' do
+        allow(client).to receive(:post).with('/v1/auth/okta/login/user1', {password: 'secure'}.to_json) { {auth: {client_token: 'abcd-1234'}} }
+        allow(client).to receive(:token=)
+        expect(auth.okta('user1', 'secure').auth.client_token).to eq('abcd-1234')
+      end
+    end
+
     describe "#region_from_sts_endpoint" do
       subject { auth.send(:region_from_sts_endpoint, sts_endpoint) }
 


### PR DESCRIPTION
Add functionality from here: https://www.vaultproject.io/docs/auth/okta.html to authenticate with Okta. Includes unit test (I believe integration tests would require an Okta account).