### PR TITLE
Fix client#shutdown to not raise error when the pool is empty

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -156,7 +156,7 @@ module Vault
 
     # Shutdown any open pool connections. Pool will be recreated upon next request.
     def shutdown
-      @nhp.shutdown()
+      @nhp.shutdown() if @nhp
       @nhp = nil
     end
 

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -111,6 +111,25 @@ module Vault
           server.close
         end
       end
+
+      it "does not raise error if the pool is empty" do
+        TCPServer.open('localhost', 0) do |server|
+          Thread.new do
+            loop do
+              client = server.accept
+              sleep 0.25
+              client.close
+            end
+          end
+
+          address = "http://%s:%s" % ["localhost", server.addr[1]]
+
+          client = described_class.new(address: address, token: "foo")
+
+          # exercise
+          expect(client.shutdown).to eq(nil)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Motivation

The method `client#shutdown` is raising error when the pool is nil

## Proposal

```ruby
@nhp.shutdown() if @nhp
```

(I think the code above explains better than a description)