### PR TITLE
Add options field for mounts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,10 @@ language: ruby
 cache: bundler
 
 env:
-  - VAULT_VERSION=0.11.4
-  - VAULT_VERSION=0.10.4
-  - VAULT_VERSION=0.9.6
-  - VAULT_VERSION=0.8.3
-  - VAULT_VERSION=0.7.3
-  - VAULT_VERSION=0.6.5
-  - VAULT_VERSION=0.5.3
+  - VAULT_VERSION=1.0.3
+  - VAULT_VERSION=1.1.5
+  - VAULT_VERSION=1.2.4
+  - VAULT_VERSION=1.3.0
 
 before_install:
   - curl -sLo vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip

--- a/lib/vault/api/sys/mount.rb
+++ b/lib/vault/api/sys/mount.rb
@@ -16,6 +16,11 @@ module Vault
     #   Type of the mount.
     #   @return [String]
     field :type
+
+    # @!attribute [r] type
+    #   Options given to the mount.
+    #   @return [Hash<Symbol, Object>]
+    field :options
   end
 
   class Sys < Request

--- a/spec/integration/api/sys/mount_spec.rb
+++ b/spec/integration/api/sys/mount_spec.rb
@@ -12,6 +12,17 @@ module Vault
         expect(sys.type).to eq("system")
         expect(sys.description).to include("system endpoints")
       end
+
+      it "shows options for mounts" do
+        next unless versioned_kv_by_default?
+
+        expect(subject.mount("mounts_kv1", "kv", "KV1", options: {version: "1"})).to be(true)
+
+        expect(subject.mounts).to be
+        secretsv2 = subject.mounts[:mounts_kv1]
+        expect(secretsv2).to be_a(Mount)
+        expect(secretsv2.options).to eq(:version => "1")
+      end
     end
 
     describe "#mount" do
@@ -21,6 +32,15 @@ module Vault
         expect(result).to be_a(Mount)
         expect(result.type).to eq("aws")
         expect(result.description).to eq("")
+      end
+
+      it "allows mounting with options" do
+        expect(subject.mount("test_kv1", "kv", "KV1", options: {version: "1"})).to be(true)
+        result = subject.mounts[:test_kv1]
+        expect(result).to be_a(Mount)
+        expect(result.type).to eq("kv")
+        expect(result.description).to eq("KV1")
+        expect(result.options).to eq(:version => "1")
       end
     end
 


### PR DESCRIPTION
* Easiest way to figure out if KV is v2 or not
* `vault_client.mounts[:secret].options => {:version=>"2"}`