### PR TITLE
Require VAULT_VERSION

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,6 +28,7 @@ RSpec.configure do |config|
   # Disable real connections.
   config.before(:suite) do
     WebMock.disable_net_connect!(allow_localhost: true)
+    abort "Must set VAULT_VERSION environment variable" if (TEST_VAULT_VERSION.to_s == '')
   end
 
   # Ensure our configuration is reset on each run.


### PR DESCRIPTION
I noticed during testing that when `VAULT_VERSION` isn't set, the test suites run til completion and throws hard to read errors like: 

`{"request_id":"bf04957a-f3a4-3e9d-75b0-ee938aae17af","lease_id":"","renewable":false,"lease_duration":0,"data":null,"wrap_info":null,"warnings":["Invalid path for a versioned K/V secrets engine. See the API docs for the appropriate API endpoints to use. If using the Vault CLI, use 'vault kv put' for this operation."],"auth":null}`
 
It looks like this is required by all tests, so this change throws an abort when the var isn't set: 

<img width="697" alt="Screen Shot 2020-04-02 at 4 51 30 PM" src="https://user-images.githubusercontent.com/12939567/78310420-c55fdd80-7502-11ea-86f9-86fae32785f5.png">
