### PR TITLE
Modify tests to work with newer versions of vault api

### DIFF
--- a/lib/vault/persistent.rb
+++ b/lib/vault/persistent.rb
@@ -1,3 +1,4 @@
+require 'pry'
 # Vendored and modified from github.com/drbrain/net-http-persistent
 #
 require 'net/http'

--- a/spec/integration/api/logical_spec.rb
+++ b/spec/integration/api/logical_spec.rb
@@ -24,13 +24,13 @@ module Vault
 
     describe "#list" do
       it "returns the empty array when no items exist" do
-        expect(subject.list("secret/that/never/existed")).to eq([])
+        expect(subject.list("secret/metadata/that/never/existed")).to eq([])
       end
 
       it "returns all secrets" do
-        subject.write("secret/test-list-1", foo: "bar")
-        subject.write("secret/test-list-2", foo: "bar")
-        secrets = subject.list("secret")
+        subject.write("secret/data/test-list-1", data: {foo: "bar"})
+        subject.write("secret/data/test-list-2", data: {foo: "bar"})
+        secrets = subject.list("secret/metadata/")
         expect(secrets).to be_a(Array)
         expect(secrets).to include("test-list-1")
         expect(secrets).to include("test-list-2")
@@ -39,76 +39,76 @@ module Vault
 
     describe "#read" do
       it "returns nil with the thing does not exist" do
-        expect(subject.read("secret/foo/bar/zip")).to be(nil)
+        expect(subject.read("secret/data/foo/bar/zip")).to be(nil)
       end
 
       it "returns the secret when it exists" do
-        subject.write("secret/test-read", foo: "bar")
-        secret = subject.read("secret/test-read")
+        subject.write("secret/data/test-read", data: {foo: "bar"})
+        secret = subject.read("secret/data/test-read")
         expect(secret).to be
-        expect(secret.data).to eq(foo: "bar")
+        expect(secret.data[:data]).to eq(foo: "bar")
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-read", foo: "bar")
-        secret = subject.read("secret/b:@c%n-read")
+        subject.write("secret/data/b:@c%n-read", data: {foo: "bar"})
+        secret = subject.read("secret/data/b:@c%n-read")
         expect(secret).to be
-        expect(secret.data).to eq(foo: "bar")
+        expect(secret.data[:data]).to eq(foo: "bar")
       end
     end
 
     describe "#write" do
       it "creates and returns the secret" do
-        subject.write("secret/test-write", zip: "zap")
-        result = subject.read("secret/test-write")
+        subject.write("secret/data/test-write", data: {zip: "zap"})
+        result = subject.read("secret/data/test-write")
         expect(result).to be
-        expect(result.data).to eq(zip: "zap")
+        expect(result.data[:data]).to eq(zip: "zap")
       end
 
       it "overwrites existing secrets" do
-        subject.write("secret/test-overwrite", zip: "zap")
-        subject.write("secret/test-overwrite", bacon: true)
-        result = subject.read("secret/test-overwrite")
+        subject.write("secret/data/test-overwrite", data: {zip: "zap"})
+        subject.write("secret/data/test-overwrite", data: {bacon: true})
+        result = subject.read("secret/data/test-overwrite")
         expect(result).to be
-        expect(result.data).to eq(bacon: true)
+        expect(result.data[:data]).to eq(bacon: true)
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-write", foo: "bar")
-        subject.write("secret/b:@c%n-write", bacon: true)
-        secret = subject.read("secret/b:@c%n-write")
+        subject.write("secret/data/b:@c%n-write", data: {foo: "bar"})
+        subject.write("secret/data/b:@c%n-write", data: {bacon: true})
+        secret = subject.read("secret/data/b:@c%n-write")
         expect(secret).to be
-        expect(secret.data).to eq(bacon: true)
+        expect(secret.data[:data]).to eq(bacon: true)
       end
 
       it "respects spaces properly" do
-        key = 'secret/sub/"Test Group"'
-        subject.write(key, foo: "bar")
-        expect(subject.list("secret/sub")).to eq(['"Test Group"'])
+        key = 'secret/data/sub/"Test Group"'
+        subject.write(key, data: {foo: "bar"})
+        expect(subject.list("secret/metadata/sub")).to eq(['"Test Group"'])
         secret = subject.read(key)
         expect(secret).to be
-        expect(secret.data).to eq(foo:"bar")
+        expect(secret.data[:data]).to eq(foo:"bar")
       end
     end
 
     describe "#delete" do
       it "deletes the secret" do
-        subject.write("secret/delete", foo: "bar")
-        expect(subject.delete("secret/delete")).to be(true)
-        expect(subject.read("secret/delete")).to be(nil)
+        subject.write("secret/data/delete", data: {foo: "bar"})
+        expect(subject.delete("secret/data/delete")).to be(true)
+        expect(subject.read("secret/data/delete")).to be(nil)
       end
 
       it "allows special characters" do
-        subject.write("secret/b:@c%n-delete", foo: "bar")
-        expect(subject.delete("secret/b:@c%n-delete")).to be(true)
-        expect(subject.read("secret/b:@c%n-delete")).to be(nil)
+        subject.write("secret/data/b:@c%n-delete", data: {foo: "bar"})
+        expect(subject.delete("secret/data/b:@c%n-delete")).to be(true)
+        expect(subject.read("secret/data/b:@c%n-delete")).to be(nil)
       end
 
       it "does not error if the secret does not exist" do
         expect {
-          subject.delete("secret/delete")
-          subject.delete("secret/delete")
-          subject.delete("secret/delete")
+          subject.delete("secret/data/delete")
+          subject.delete("secret/data/delete")
+          subject.delete("secret/data/delete")
         }.to_not raise_error
       end
     end
@@ -122,7 +122,7 @@ module Vault
         expect(unwrapped.auth.client_token).to be
 
         vault_test_client.with_token(unwrapped.auth.client_token) do |client|
-          expect { client.logical.read("secret/test") }.to_not raise_error
+          expect { client.logical.read("secret/data/test") }.to_not raise_error
         end
       end
     end
@@ -135,7 +135,7 @@ module Vault
         expect(unwrapped).to be
 
         vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical.read("secret/test") }.to_not raise_error
+          expect { client.logical.read("secret/data/test") }.to_not raise_error
         end
       end
 
@@ -146,7 +146,7 @@ module Vault
         expect(unwrapped).to be
 
         vault_test_client.with_token(unwrapped) do |client|
-          expect { client.logical.read("secret/test") }.to_not raise_error
+          expect { client.logical.read("secret/data/test") }.to_not raise_error
         end
       end
 

--- a/spec/integration/redirection_spec.rb
+++ b/spec/integration/redirection_spec.rb
@@ -34,14 +34,14 @@ module Vault
       end
 
       it "handles redirections properly in PUT requests" do
-        redirected_client.put("/v1/secret/redirect", { works: true }.to_json)
-        expect(vault_test_client.logical.read('secret/redirect').data[:works]).to eq(true)
+        redirected_client.put("/v1/secret/data/redirect", {data: { works: true }}.to_json)
+        expect(vault_test_client.logical.read('secret/data/redirect').data[:data][:works]).to eq(true)
       end
 
       it "handles redirections properly in DELETE requests" do
-        vault_test_client.logical.write('secret/redirect', { deleted: false })
-        redirected_client.delete("/v1/secret/redirect")
-        expect(vault_test_client.logical.read('secret/redirect')).to be_nil
+        vault_test_client.logical.write('secret/data/redirect', data: { deleted: false })
+        redirected_client.delete("/v1/secret/data/redirect")
+        expect(vault_test_client.logical.read('secret/data/redirect')).to be_nil
       end
 
       it "handles redirections properly in POST requests" do

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake",    "~> 12.0"
   spec.add_development_dependency "rspec",   "~> 3.5"
   spec.add_development_dependency "yard"
-  spec.add_development_dependency "webmock", "~> 2.3"
+  spec.add_development_dependency "webmock"
+  spec.add_development_dependency "byebug"
 end


### PR DESCRIPTION
Data objects and paths weren't present causing issues with newer vault api specs.
List was not targeting metadata path.

This PR moves to have the tests use the newer vault apis by default. I haven't tested these changes with an older version of vault, but onwards and upwards I say!

Let me know if you need any more information about this.