### PR TITLE
Locking aws-sigv4 at 1.1.1

### DIFF
--- a/vault.gemspec
+++ b/vault.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sigv4"
+  spec.add_runtime_dependency "aws-sigv4", "1.1.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
1.1.2 has changes that break the tests. As such, we're locking it here for now.