### PR TITLE
Adds support for passing a namespace as an option to a single request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Vault Ruby Changelog
 
+## v0.13.2 (April 30, 2020)
+
+BUG FIXES
+
+- Fixed an issue where a namespace passed to a single request was being ignored.
+
 ## v0.13.1 (April 28, 2020)
 
 IMPROVEMENTS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Vault Ruby Changelog
 
-## v0.13.2 (April 30, 2020)
-
-BUG FIXES
-
-- Fixed an issue where a namespace passed to a single request was being ignored.
-
 ## v0.13.1 (April 28, 2020)
 
 IMPROVEMENTS

--- a/lib/vault/request.rb
+++ b/lib/vault/request.rb
@@ -29,6 +29,7 @@ module Vault
     def extract_headers!(options = {})
       extract = {
         wrap_ttl: Vault::Client::WRAP_TTL_HEADER,
+        namespace: Vault::Client::NAMESPACE_HEADER,
       }
 
       {}.tap do |h|

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -159,6 +159,16 @@ module Vault
             expect(subject.logical.read("secret/sekkrit").data).to eq(foo: "bar")
           end
         end
+
+        context "when using a namespace as part of the request options" do
+          subject { vault_test_client }
+
+          it "should respect namespace boundaries" do
+            subject.logical.write("secret/sekkrit", { foo: "bar" }, namespace: "bar/baz")
+            expect(subject.logical.read("secret/sekkrit")).to eq(nil)
+            expect(subject.logical.read("secret/sekkrit", namespace: "bar/baz").data).to eq(foo: "bar")
+          end
+        end
       end
 
       context "when using a non-enterprise version", non_ent_vault: ">= 0.13" do


### PR DESCRIPTION
As it stands, any namespace that gets passed to a single request (e.g. `client.logical.read("secrets/data/foo", data: { foo: "bar" }, namespace: "baz")`) will be completely ignored.

This change addresses this issue and adds a test to check that functionality.