### PR TITLE
Relax aws-sigv4 dependency

### DIFF
--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -225,9 +225,14 @@ module Vault
 
       let!(:old_token) { subject.token }
       let(:credentials_provider) do
-        double(
-          credentials:
-            double(access_key_id: 'very', secret_access_key: 'secure', session_token: 'thing')
+        instance_double(
+          Aws::Sigv4::StaticCredentialsProvider,
+          credentials: instance_double(
+            Aws::Sigv4::Credentials,
+            access_key_id: 'very',
+            secret_access_key: 'secure',
+            session_token: 'thing'
+          )
         )
       end
       let(:secret) { double(auth: double(client_token: 'a great token')) }
@@ -243,7 +248,7 @@ module Vault
           ).and_call_original
         )
         expect do
-          subject.auth.aws_iam('a_rolename', credentials_provider, 'mismatched_iam_header', 'https://sts.cn-north-1.amazonaws.com.cn') 
+          subject.auth.aws_iam('a_rolename', credentials_provider, 'mismatched_iam_header', 'https://sts.cn-north-1.amazonaws.com.cn')
         end.to raise_error(Vault::HTTPClientError, /expected "?iam_header_canary"? but got "?mismatched_iam_header"?/)
       end
 

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sigv4", "1.1.1"
+  spec.add_runtime_dependency "aws-sigv4"
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "pry",     "~> 0.13.1"


### PR DESCRIPTION
Hi! I noticed that vault-ruby 0.13.1 locked aws-sigv4 at 1.1.1. If I got it right, it was because of an issue with 1.1.2 that caused vault-ruby specs to fail. Since then, there was an update in aws-sigv4 1.1.3 that fixes the issue that was causing specs to fail:

https://github.com/aws/aws-sdk-ruby/pull/2291

In this PR I'm proposing to relax this dependency again and to remove the lock on 1.1.1. I also did a small change to replace regular doubles by verifying doubles so, in case of interface changes, there is a feedback about those changes.