### PR TITLE
aws-sigv4 was updated, issues from 1.1.2 fixed

### DIFF
--- a/vault.gemspec
+++ b/vault.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "aws-sigv4", "1.1.1"
+  spec.add_runtime_dependency "aws-sigv4", "~> 1.1"
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "pry",     "~> 0.13.1"


### PR DESCRIPTION
aws-sigv4 1.1.2 broke our tests. 1.1.3 has fixed our issues, so we're removing that restriction to 1.1.1