### PR TITLE
Add Transform Secrets engine support

### DIFF
--- a/lib/vault/api.rb
+++ b/lib/vault/api.rb
@@ -9,5 +9,6 @@ module Vault
     require_relative "api/logical"
     require_relative "api/secret"
     require_relative "api/sys"
+    require_relative "api/transform"
   end
 end

--- a/lib/vault/api/transform.rb
+++ b/lib/vault/api/transform.rb
@@ -18,22 +18,6 @@ module Vault
     def decode
       # Do some decoding
     end
-
-    def role
-      @role ||= Role.new(self.client)
-    end
-
-    def transformation
-      @transformation ||= Transformation.new(self.client)
-    end
-
-    def template
-      @template ||= Template.new(self.client)
-    end
-
-    def alphabet
-      @alphabet ||= Alphabet.new(self.client)
-    end
   end
 end
 

--- a/lib/vault/api/transform.rb
+++ b/lib/vault/api/transform.rb
@@ -1,0 +1,43 @@
+require_relative '../client'
+require_relative '../request'
+
+class Vault
+  class Client
+    # A proxy to the {Transform} methods.
+    # @return [Transform]
+    def transform
+      @transform ||= Transform.new(self)
+    end
+  end
+
+  class Transform < Request
+    def encode
+      # Do some encoding
+    end
+
+    def decode
+      # Do some decoding
+    end
+
+    def role
+      @role ||= Role.new(self.client)
+    end
+
+    def transformation
+      @transformation ||= Transformation.new(self.client)
+    end
+
+    def template
+      @template ||= Template.new(self.client)
+    end
+
+    def alphabet
+      @alphabet ||= Alphabet.new(self.client)
+    end
+  end
+end
+
+require_relative 'transform/alphabet'
+require_relative 'transform/role'
+require_relative 'transform/template'
+require_relative 'transform/transformation'

--- a/lib/vault/api/transform.rb
+++ b/lib/vault/api/transform.rb
@@ -1,7 +1,7 @@
 require_relative '../client'
 require_relative '../request'
 
-class Vault
+module Vault
   class Client
     # A proxy to the {Transform} methods.
     # @return [Transform]

--- a/lib/vault/api/transform.rb
+++ b/lib/vault/api/transform.rb
@@ -11,15 +11,13 @@ module Vault
   end
 
   class Transform < Request
-    def encode(role_name:, value:, **opts)
+    def encode(role_name:, **opts)
       opts ||= {}
-      opts[:value] = value
       client.post("/v1/transform/encode/#{encode_path(role_name)}", JSON.fast_generate(opts))
     end
 
-    def decode(role_name:, value:, **opts)
+    def decode(role_name:, **opts)
       opts ||= {}
-      opts[:value] = value
       client.post("/v1/transform/decode/#{encode_path(role_name)}", JSON.fast_generate(opts))
     end
   end

--- a/lib/vault/api/transform.rb
+++ b/lib/vault/api/transform.rb
@@ -11,12 +11,16 @@ module Vault
   end
 
   class Transform < Request
-    def encode
-      # Do some encoding
+    def encode(role_name:, value:, **opts)
+      opts ||= {}
+      opts[:value] = value
+      client.post("/v1/transform/encode/#{encode_path(role_name)}", JSON.fast_generate(opts))
     end
 
-    def decode
-      # Do some decoding
+    def decode(role_name:, value:, **opts)
+      opts ||= {}
+      opts[:value] = value
+      client.post("/v1/transform/decode/#{encode_path(role_name)}", JSON.fast_generate(opts))
     end
   end
 end

--- a/lib/vault/api/transform/alphabet.rb
+++ b/lib/vault/api/transform/alphabet.rb
@@ -1,0 +1,7 @@
+class Vault
+  class Transform < Request
+    class Alphabet < Request
+
+    end
+  end
+end

--- a/lib/vault/api/transform/alphabet.rb
+++ b/lib/vault/api/transform/alphabet.rb
@@ -1,7 +1,40 @@
+require_relative '../../request'
+require_relative '../../response'
+
 module Vault
   class Transform < Request
-    class Alphabet < Request
+    class Alphabet < Response
+      field :alphabet
+    end
 
+    def create_alphabet(name, alphabet:, **opts)
+      opts ||= {}
+      opts[:alphabet] = alphabet
+      client.post("/v1/transform/alphabet/#{encode_path(name)}", JSON.fast_generate(opts))
+      return true
+    end
+
+    def get_alphabet(name)
+      json = client.get("/v1/transform/alphabet/#{encode_path(name)}")
+      if data = json.dig(:data)
+        Alphabet.decode(data)
+      else
+        json
+      end
+    end
+
+    def delete_alphabet(name)
+      client.delete("/v1/transform/alphabet/#{encode_path(name)}")
+      true
+    end
+
+    def alphabets
+      json = client.list("/v1/transform/alphabet")
+      if keys = json.dig(:data, :keys)
+        keys
+      else
+        json
+      end
     end
   end
 end

--- a/lib/vault/api/transform/alphabet.rb
+++ b/lib/vault/api/transform/alphabet.rb
@@ -1,4 +1,4 @@
-class Vault
+module Vault
   class Transform < Request
     class Alphabet < Request
 

--- a/lib/vault/api/transform/alphabet.rb
+++ b/lib/vault/api/transform/alphabet.rb
@@ -4,6 +4,9 @@ require_relative '../../response'
 module Vault
   class Transform < Request
     class Alphabet < Response
+      # @!attribute [r] id
+      #   String listing all possible characters of the alphabet
+      #   @return [String]
       field :alphabet
     end
 

--- a/lib/vault/api/transform/role.rb
+++ b/lib/vault/api/transform/role.rb
@@ -1,0 +1,7 @@
+class Vault
+  class Transform < Request
+    class Role < Request
+
+    end
+  end
+end

--- a/lib/vault/api/transform/role.rb
+++ b/lib/vault/api/transform/role.rb
@@ -1,4 +1,4 @@
-class Vault
+module Vault
   class Transform < Request
     class Role < Request
 

--- a/lib/vault/api/transform/role.rb
+++ b/lib/vault/api/transform/role.rb
@@ -4,6 +4,9 @@ require_relative '../../response'
 module Vault
   class Transform < Request
     class Role < Response
+      # @!attribute [r] transformations
+      #   Array of all transformations the role has access to
+      #   @return [Array<String>]
       field :transformations
     end
 

--- a/lib/vault/api/transform/role.rb
+++ b/lib/vault/api/transform/role.rb
@@ -1,7 +1,39 @@
+require_relative '../../request'
+require_relative '../../response'
+
 module Vault
   class Transform < Request
-    class Role < Request
+    class Role < Response
+      field :transformations
+    end
 
+    def create_role(name, **opts)
+      opts ||= {}
+      client.post("/v1/transform/role/#{encode_path(name)}", JSON.fast_generate(opts))
+      return true
+    end
+
+    def get_role(name)
+      json = client.get("/v1/transform/role/#{encode_path(name)}")
+      if data = json.dig(:data)
+        Role.decode(data)
+      else
+        json
+      end
+    end
+
+    def delete_role(name)
+      client.delete("/v1/transform/role/#{encode_path(name)}")
+      true
+    end
+
+    def roles
+      json = client.list("/v1/transform/role")
+      if keys = json.dig(:data, :keys)
+        keys
+      else
+        json
+      end
     end
   end
 end

--- a/lib/vault/api/transform/template.rb
+++ b/lib/vault/api/transform/template.rb
@@ -33,11 +33,8 @@ module Vault
 
     def templates
       json = client.list("/v1/transform/template")
-      if key_info = json.dig(:data, :key_info)
-        key_info.each do |k,v|
-          p v
-          hash[k.to_s.chomp("/").to_sym] = Template.decode(v)
-        end
+      if keys = json.dig(:data, :keys)
+        keys
       else
         json
       end

--- a/lib/vault/api/transform/template.rb
+++ b/lib/vault/api/transform/template.rb
@@ -1,7 +1,7 @@
 require_relative '../../request'
 require_relative '../../response'
 
-class Vault
+module Vault
   class Transform < Request
     class Template < Response
       field :alphabet

--- a/lib/vault/api/transform/template.rb
+++ b/lib/vault/api/transform/template.rb
@@ -1,0 +1,46 @@
+require_relative '../../request'
+require_relative '../../response'
+
+class Vault
+  class Transform < Request
+    class Template < Response
+      field :alphabet
+      field :pattern
+      field :type
+    end
+
+    def create_template(name, type:, pattern:, **opts)
+      opts ||= {}
+      opts[:type] = type
+      opts[:pattern] = pattern
+      client.post("/v1/transform/template/#{encode_path(name)}", JSON.fast_generate(opts))
+      return true
+    end
+
+    def get_template(name)
+      json = client.get("/v1/transform/template/#{encode_path(name)}")
+      if data = json.dig(:data)
+        Template.decode(data)
+      else
+        json
+      end
+    end
+
+    def delete_template(name)
+      client.delete("/v1/transform/template/#{encode_path(name)}")
+      true
+    end
+
+    def templates
+      json = client.list("/v1/transform/template")
+      if key_info = json.dig(:data, :key_info)
+        key_info.each do |k,v|
+          p v
+          hash[k.to_s.chomp("/").to_sym] = Template.decode(v)
+        end
+      else
+        json
+      end
+    end
+  end
+end

--- a/lib/vault/api/transform/template.rb
+++ b/lib/vault/api/transform/template.rb
@@ -4,8 +4,19 @@ require_relative '../../response'
 module Vault
   class Transform < Request
     class Template < Response
+      # @!attribute [r] alphabet
+      #   Name of the alphabet to be used in the template
+      #   @return [String]
       field :alphabet
+
+      # @!attribute [r] pattern
+      #   Regex string to detect and match for the template
+      #   @return [String]
       field :pattern
+
+      # @!attribute [r] type
+      #   Type of the template, currently, only "regex" is supported
+      #   @return [String]
       field :type
     end
 

--- a/lib/vault/api/transform/transformation.rb
+++ b/lib/vault/api/transform/transformation.rb
@@ -1,4 +1,4 @@
-class Vault
+module Vault
   class Transform < Request
     class Transformation < Request
 

--- a/lib/vault/api/transform/transformation.rb
+++ b/lib/vault/api/transform/transformation.rb
@@ -1,0 +1,7 @@
+class Vault
+  class Transform < Request
+    class Transformation < Request
+
+    end
+  end
+end

--- a/lib/vault/api/transform/transformation.rb
+++ b/lib/vault/api/transform/transformation.rb
@@ -4,9 +4,26 @@ require_relative '../../response'
 module Vault
   class Transform < Request
     class Transformation < Response
+      # @!attribute [r] allowed_roles
+      #   Array of role names that are allowed to use this transformation
+      #   @return [Array<String>]
       field :allowed_roles
+
+      # @!attribute [r] templates
+      #   Array of template names accessible to this transformation
+      #   @return [Array<String>]
       field :templates
+
+      # @!attribute [r] tweak_source
+      #   String representing how a tweak is provided for this transformation.
+      #   Available tweaks are "supplied", "generated", and "internal"
+      #   @return [String]
       field :tweak_source
+
+      # @!attribute [r] type
+      #   String representing the type of transformation this is.
+      #   Available types are "fpe", and "masking"
+      #   @return [String]
       field :type
     end
 

--- a/lib/vault/api/transform/transformation.rb
+++ b/lib/vault/api/transform/transformation.rb
@@ -1,7 +1,44 @@
+require_relative '../../request'
+require_relative '../../response'
+
 module Vault
   class Transform < Request
-    class Transformation < Request
+    class Transformation < Response
+      field :allowed_roles
+      field :templates
+      field :tweak_source
+      field :type
+    end
 
+    def create_transformation(name, type:, template:, **opts)
+      opts ||= {}
+      opts[:type] = type
+      opts[:template] = template
+      client.post("/v1/transform/transformation/#{encode_path(name)}", JSON.fast_generate(opts))
+      return true
+    end
+
+    def get_transformation(name)
+      json = client.get("/v1/transform/transformation/#{encode_path(name)}")
+      if data = json.dig(:data)
+        Transformation.decode(data)
+      else
+        json
+      end
+    end
+
+    def delete_transformation(name)
+      client.delete("/v1/transform/transformation/#{encode_path(name)}")
+      true
+    end
+
+    def transformations
+      json = client.list("/v1/transform/transformation")
+      if keys = json.dig(:data, :keys)
+        keys
+      else
+        json
+      end
     end
   end
 end

--- a/spec/integration/api/transform_spec.rb
+++ b/spec/integration/api/transform_spec.rb
@@ -13,6 +13,7 @@ module Vault
       vault_test_client.transform.create_transformation("foo_trans", type: "fpe", template: "builtin/creditcardnumber", allowed_roles: ["foo_role"])
     end
 
+    # Lists of possible input options for a given transform type
     base_names = Proc.new { SecureRandom.alphanumeric(5) }
     trans_types = ['fpe', 'masking']
     trans_tweak_sources = ['supplied', 'generated', 'internal']
@@ -21,6 +22,7 @@ module Vault
     temp_patterns = ['\d{3}-\d{2}-\d{4}', '\d{3}-\d{3}-\d{4}', '\d{4}-\d{4}-\d{4}-\d{4}']
     alpha_sets = ['1234567890abcdef', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ']
 
+    # A list of all Transform Secret types and the arguments they accept/require
     transform_types = {
       role: { name: base_names, other_attrs: { transformations: [["foo_trans"]] } },
       transformation: { name: base_names, other_attrs: { type: trans_types, tweak_source: trans_tweak_sources, template: trans_templates } },
@@ -29,10 +31,13 @@ module Vault
     }
 
     transform_types.each do |type, attrs|
+      # With a given type...
       context "#{type.capitalize}" do
         attr_values = attrs[:other_attrs].values
         attr_keys = attrs[:other_attrs].keys
 
+        # Iterate over its possible input options to provide a full permutation of options
+        # i.e. if I have a type with 3 inputs that have 3 options each, this will provide all 27 permutations for testing 
         (0...(attr_values[0]&.length || 1)).each do |index_0|
           (0...(attr_values[1]&.length || 1)).each do |index_1|
             (0...(attr_values[2]&.length || 1)).each do |index_2|

--- a/spec/integration/api/transform_spec.rb
+++ b/spec/integration/api/transform_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+require 'securerandom'
+
+module Vault
+  describe Transform, ent_vault: ">= 1.4" do
+    subject { vault_test_client }
+
+    before(:context) do
+      vault_test_client.sys.mount(
+        "transform", "transform", "transform"
+      )
+      vault_test_client.transform.create_role("foo_role", transformations: ["foo_trans"])
+      vault_test_client.transform.create_transformation("foo_trans", type: "fpe", template: "builtin/creditcardnumber", allowed_roles: ["foo_role"])
+    end
+
+    base_names = Proc.new { SecureRandom.alphanumeric(5) }
+    trans_types = ['fpe', 'masking']
+    trans_tweak_sources = ['supplied', 'generated', 'internal']
+    trans_templates = ['builtin/creditcardnumber', 'builtin/socialsecuritynumber']
+    temp_types = ["regex"]
+    temp_patterns = ['\d{3}-\d{2}-\d{4}', '\d{3}-\d{3}-\d{4}', '\d{4}-\d{4}-\d{4}-\d{4}']
+    alpha_sets = ['1234567890abcdef', 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ']
+
+    transform_types = {
+      role: { name: base_names, other_attrs: { transformations: [["foo_trans"]] } },
+      transformation: { name: base_names, other_attrs: { type: trans_types, tweak_source: trans_tweak_sources, template: trans_templates } },
+      template: { name: base_names, other_attrs: { type: temp_types, pattern: temp_patterns } },
+      alphabet: { name: base_names, other_attrs: { alphabet: alpha_sets } },
+    }
+
+    transform_types.each do |type, attrs|
+      context "#{type.capitalize}" do
+        attr_values = attrs[:other_attrs].values
+        attr_keys = attrs[:other_attrs].keys
+
+        (0...(attr_values[0]&.length || 1)).each do |index_0|
+          (0...(attr_values[1]&.length || 1)).each do |index_1|
+            (0...(attr_values[2]&.length || 1)).each do |index_2|
+              let(:opts) do
+                opts = {}
+                opts[attr_keys[0].to_sym] = attr_values[0][index_0] if attr_values[0]
+                opts[attr_keys[1].to_sym] = attr_values[1][index_1] if attr_values[1]
+                opts[attr_keys[2].to_sym] = attr_values[2][index_2] if attr_values[2]
+                opts
+              end
+              
+              before(:context) do
+                @name = "#{attrs[:name].call}_#{type}".downcase
+              end
+
+              context "CRUD", order: :defined do
+                describe "#create_#{type}" do
+                  it "creates a #{type} in the vault server" do
+                    subject.transform.send("create_#{type}", @name, **opts)
+                    expected_opts = opts.clone
+                    expected_opts.delete(:tweak_source) if opts[:tweak_source] == "internal"
+                    if type == :transformation
+                      expected_opts[:allowed_roles] = [] 
+                      expected_opts[:templates] = [opts[:template]]
+                    end
+
+                    expected = Vault::Transform.const_get(type.to_s.capitalize).new(expected_opts)
+                    expect(subject.transform.send("get_#{type}", @name)).to eq(expected)
+                  end
+                end
+
+                describe "##{type}s" do
+                  it "lists the names of all #{type}s present on the vault server" do
+                    expect(subject.transform.send("#{type}s")).to include(@name)
+                  end
+                end
+
+                describe "#delete_#{type}" do
+                  it "removes the #{type} from the server" do
+                    subject.transform.send("delete_#{type}", @name)
+                    sleep 0.1
+                    expect(subject.transform.send("#{type}s")).not_to include(@name)
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+
+    describe "#encode and #decode" do
+      let(:value) { "4111-1111-1111-1111"}
+      let(:tweak) { Base64.encode64("somenum") }
+      it "encodes a value with a supplied tweak value then decodes it to the original value" do
+        resp = subject.transform.encode(role_name: "foo_role", value: value, tweak: tweak)
+        encoded_value = resp[:data][:encoded_value]
+        expect(encoded_value).to match(/\d{4}-\d{4}-\d{4}-\d{4}/)
+        expect(encoded_value).not_to eq(value)
+        resp = subject.transform.decode(role_name: "foo_role", value: encoded_value, tweak: tweak)
+        expect(resp[:data][:decoded_value]).to eq(value)
+      end
+
+      it "does not output the original value if the same tweak was not supplied" do
+        resp = subject.transform.encode(role_name: "foo_role", value: value, tweak: tweak)
+        encoded_value = resp[:data][:encoded_value]
+        resp = subject.transform.decode(role_name: "foo_role", value: encoded_value, tweak: Base64.encode64("numsome"))
+        expect(resp[:data][:decoded_value]).to_not eq(value)
+        expect(resp[:data][:decoded_value]).to_not eq(encoded_value)
+        expect(resp[:data][:decoded_value]).to match(/\d{4}-\d{4}-\d{4}-\d{4}/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR seeks to add support for the Transform Secrets engine, which is able to be used by Vault Enterprise customers. It allows for in-place encryption, as well as masking through `encode` and `decode` methods, as well as providing the ability to create templates and transformations to handle any custom data a user may have in their database.

<details>
  <summary>Test run example</summary>

```
Vault::Transform
  #encode and #decode
    with batch_input
      does not output the original value if the same tweak was not supplied
      encodes a value with a supplied tweak value then decodes it to the original value
    with single values
      encodes a value with a supplied tweak value then decodes it to the original value
      does not output the original value if the same tweak was not supplied
      with a transformation
        with a masking type
          and a social security template
            encodes a value, providing the masked value
          and a credit card template
            encodes a value, providing the masked value
        with an fpe type
          and a social security template
            and a supplied tweak source
              encodes a value and decodes it to the original value
            and a generated tweak source
              encodes a value and decodes it to the original value
            and an internal tweak source
              encodes a value and decodes it to the original value
          and a credit card template
            and a generated tweak source
              encodes a value and decodes it to the original value
            and an internal tweak source
              encodes a value and decodes it to the original value
            and a supplied tweak source
              encodes a value and decodes it to the original value
  Template
    CRUD
      #create_template
        creates a template in the vault server with {:type=>"regex", :pattern=>"\\d{4}-\\d{4}-\\d{4}-\\d{4}"}
      #templates
        lists the names of all templates present on the vault server
      #delete_template
        removes the template from the server
    CRUD
      #create_template
        creates a template in the vault server with {:type=>"regex", :pattern=>"\\d{3}-\\d{3}-\\d{4}"}
      #templates
        lists the names of all templates present on the vault server
      #delete_template
        removes the template from the server
    CRUD
      #create_template
        creates a template in the vault server with {:type=>"regex", :pattern=>"\\d{3}-\\d{2}-\\d{4}"}
      #templates
        lists the names of all templates present on the vault server
      #delete_template
        removes the template from the server
  Transformation
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"fpe", :tweak_source=>"supplied", :template=>"builtin/creditcardnumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"masking", :tweak_source=>"supplied", :template=>"builtin/socialsecuritynumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"fpe", :tweak_source=>"generated", :template=>"builtin/socialsecuritynumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"fpe", :tweak_source=>"supplied", :template=>"builtin/socialsecuritynumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"masking", :tweak_source=>"supplied", :template=>"builtin/creditcardnumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"masking", :tweak_source=>"generated", :template=>"builtin/creditcardnumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"masking", :tweak_source=>"internal", :template=>"builtin/creditcardnumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"fpe", :tweak_source=>"internal", :template=>"builtin/creditcardnumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"fpe", :tweak_source=>"internal", :template=>"builtin/socialsecuritynumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"masking", :tweak_source=>"generated", :template=>"builtin/socialsecuritynumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"masking", :tweak_source=>"internal", :template=>"builtin/socialsecuritynumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
    CRUD
      #create_transformation
        creates a transformation in the vault server with {:type=>"fpe", :tweak_source=>"generated", :template=>"builtin/creditcardnumber"}
      #transformations
        lists the names of all transformations present on the vault server
      #delete_transformation
        removes the transformation from the server
  Alphabet
    CRUD
      #create_alphabet
        creates a alphabet in the vault server with {:alphabet=>"1234567890abcdef"}
      #alphabets
        lists the names of all alphabets present on the vault server
      #delete_alphabet
        removes the alphabet from the server
    CRUD
      #create_alphabet
        creates a alphabet in the vault server with {:alphabet=>"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"}
      #alphabets
        lists the names of all alphabets present on the vault server
      #delete_alphabet
        removes the alphabet from the server
  Role
    CRUD
      #create_role
        creates a role in the vault server with {:transformations=>["foo_trans"]}
      #roles
        lists the names of all roles present on the vault server
      #delete_role
        removes the role from the server

Finished in 0.45216 seconds (files took 0.70311 seconds to load)
66 examples, 0 failures
```

</details>