### PR TITLE
Add accessor to sys.auths response

### DIFF
--- a/lib/vault/api/sys/auth.rb
+++ b/lib/vault/api/sys/auth.rb
@@ -11,6 +11,11 @@ module Vault
     #   Name of the auth backend.
     #   @return [String]
     field :type
+
+    # @!attribute [r] accessor
+    #   Accessor of the auth backend.
+    #   @return [String]
+    field :accessor
   end
 
   class AuthConfig < Response
@@ -29,7 +34,7 @@ module Vault
     # List all auths in Vault.
     #
     # @example
-    #   Vault.sys.auths #=> {:token => #<Vault::Auth type="token", description="token based credentials">}
+    #   Vault.sys.auths #=> {:token => #<Vault::Auth type="token", description="token based credentials", accessor="auth_token_d73f8a39">}
     #
     # @return [Hash<Symbol, Auth>]
     def auths

--- a/spec/integration/api/sys/auth_spec.rb
+++ b/spec/integration/api/sys/auth_spec.rb
@@ -5,8 +5,13 @@ module Vault
     subject { vault_test_client.sys }
 
     describe "#auths" do
-      it "returns the list of auths" do
+      it "returns the list of auths with fields" do
         expect(subject.auths).to be
+        auths = subject.auths
+        expect(auths[:token]).to be
+        expect(auths[:token].type).to eq('token')
+        expect(auths[:token].description).to eq('token based credentials')
+        expect(auths[:token].accessor).to be
       end
     end
 


### PR DESCRIPTION
Hi! Returning the accessor with sys.auths would simplify some work we're doing for managing auth methods.

I added tests, with I think the reasonable assumption that the token auth mount is always created and that we don't need to test the value of the accessor since it is not feasibly predictable (I gather that Vault's golang tests also make this assumption).

The existing tests are somewhat bare. Is this sufficient, and reasonably in line with existing tests? Thanks : )