### PR TITLE
Fix gemspec to not require git on system

### DIFF
--- a/vault.gemspec
+++ b/vault.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/hashicorp/vault-ruby"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["lib/**/**/**"]
+  spec.files        += ["README.md", "CHANGELOG.md", "LICENSE"]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]


### PR DESCRIPTION
The current gemspec files retrieves the list of files to include via Git.

On systems without git, this will result in an error on even trying to load the Gem as the gemspec gets re-evaluated.

I changed the dynamic to a static list/glob, but kept the following files out of the Gem:

```
.circleci/config.yml
.github/workflows/jira.yaml
.gitignore
.rspec
Gemfile
Rakefile
vault.gemspec
```

Verified the new Gem works on my vanilla (Windows 2019) machine now.