### PR TITLE
Make connection pool timeout configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Vault Ruby Changelog
 
+## v0.16.0 (??? ??, 2021)
+
+IMPROVEMENTS
+
+- The timeout used to get a connection from the connection pool that talks with vault is now configurable. Using `Vault.pool_timeout` or the env var `VAULT_POOL_TIMEOUT`.
+
 ## v0.15.0 (July 29, 2020)
 
 IMPROVEMENTS

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Development
 Important Notes:
 
 - **All new features must include test coverage.** At a bare minimum, Unit tests are required. It is preferred if you include integration tests as well.
-- **The tests must be be idempotent.** The HTTP calls made during a test should be able to be run over and over.
+- **The tests must be idempotent.** The HTTP calls made during a test should be able to be run over and over.
 - **Tests are order independent.** The default RSpec configuration randomizes the test order, so this should not be a problem.
 - **Integration tests require Vault**  Vault must be available in the path for the integration tests to pass.
    - **In order to be considered an integration test:** The test MUST use the `vault_test_client` or `vault_redirect_test_client` as the client. This spawns a process, or uses an already existing process from another test, to run against.

--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -86,7 +86,7 @@ module Vault
       @lock.synchronize do
         return @nhp if @nhp
 
-        @nhp = PersistentHTTP.new("vault-ruby", nil, pool_size)
+        @nhp = PersistentHTTP.new("vault-ruby", nil, pool_size, pool_timeout)
 
         if proxy_address
           proxy_uri = URI.parse "http://#{proxy_address}"

--- a/lib/vault/configurable.rb
+++ b/lib/vault/configurable.rb
@@ -14,6 +14,7 @@ module Vault
         :proxy_port,
         :proxy_username,
         :pool_size,
+        :pool_timeout,
         :read_timeout,
         :ssl_ciphers,
         :ssl_pem_contents,

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -88,7 +88,7 @@ module Vault
       # @return Integer
       def pool_size
         if var = ENV["VAULT_POOL_SIZE"]
-          return var.to_i
+          var.to_i
         else
           DEFAULT_POOL_SIZE
         end
@@ -98,7 +98,7 @@ module Vault
       # @return Float
       def pool_timeout
         if var = ENV["VAULT_POOL_TIMEOUT"]
-          return var.to_f
+          var.to_f
         else
           DEFAULT_POOL_TIMEOUT
         end

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -30,6 +30,9 @@ module Vault
     # The default size of the connection pool
     DEFAULT_POOL_SIZE = 16
 
+    # The default timeout for retrieving a connection from the connection pool
+    DEFAULT_POOL_TIMEOUT = 16
+
     # The set of exceptions that are detect and retried by default
     # with `with_retries`
     RETRIED_EXCEPTIONS = [HTTPServerError]
@@ -88,6 +91,16 @@ module Vault
           return var.to_i
         else
           DEFAULT_POOL_SIZE
+        end
+      end
+
+      # The timeout for getting a connection from the connection pool that communicates with Vault
+      # @return Float
+      def pool_timeout
+        if var = ENV["VAULT_POOL_SIZE"]
+          return var.to_f
+        else
+          DEFAULT_POOL_TIMEOUT
         end
       end
 

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -30,8 +30,8 @@ module Vault
     # The default size of the connection pool
     DEFAULT_POOL_SIZE = 16
 
-    # The default timeout for retrieving a connection from the connection pool
-    DEFAULT_POOL_TIMEOUT = 16
+    # The default timeout in seconds for retrieving a connection from the connection pool
+    DEFAULT_POOL_TIMEOUT = 0.5
 
     # The set of exceptions that are detect and retried by default
     # with `with_retries`

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -97,7 +97,7 @@ module Vault
       # The timeout for getting a connection from the connection pool that communicates with Vault
       # @return Float
       def pool_timeout
-        if var = ENV["VAULT_POOL_SIZE"]
+        if var = ENV["VAULT_POOL_TIMEOUT"]
           return var.to_f
         else
           DEFAULT_POOL_TIMEOUT

--- a/lib/vault/persistent.rb
+++ b/lib/vault/persistent.rb
@@ -203,11 +203,6 @@ class PersistentHTTP
   HAVE_OPENSSL = defined? OpenSSL::SSL # :nodoc:
 
   ##
-  # The default connection pool size is 1/4 the allowed open files.
-
-  DEFAULT_POOL_SIZE = 16
-
-  ##
   # The version of PersistentHTTP you are using
 
   VERSION = '3.0.0'
@@ -505,7 +500,7 @@ class PersistentHTTP
   # Defaults to 1/4 the number of allowed file handles.  You can have no more
   # than this many threads with active HTTP transactions.
 
-  def initialize name=nil, proxy=nil, pool_size=DEFAULT_POOL_SIZE
+  def initialize name=nil, proxy=nil, pool_size=Vault::Defaults::DEFAULT_POOL_SIZE, pool_timeout=Vault::Defaults::DEFAULT_POOL_TIMEOUT
     @name = name
 
     @debug_output     = nil
@@ -525,7 +520,7 @@ class PersistentHTTP
     @socket_options << [Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1] if
       Socket.const_defined? :TCP_NODELAY
 
-    @pool = PersistentHTTP::Pool.new size: pool_size do |http_args|
+    @pool = PersistentHTTP::Pool.new size: pool_size, timeout: pool_timeout do |http_args|
       PersistentHTTP::Connection.new Net::HTTP, http_args, @ssl_generation
     end
 

--- a/lib/vault/persistent/pool.rb
+++ b/lib/vault/persistent/pool.rb
@@ -31,7 +31,7 @@ class PersistentHTTP::Pool < Vault::ConnectionPool # :nodoc:
     stack  = stacks[net_http_args]
 
     if stack.empty? then
-      conn = @available.pop connection_args: net_http_args
+      conn = @available.pop @timeout, connection_args: net_http_args
     else
       conn = stack.last
     end

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -85,6 +85,22 @@ module Vault
       end
     end
 
+    describe ".pool_size" do
+      it "defaults to ENV['VAULT_POOL_SIZE']" do
+        with_stubbed_env("VAULT_POOL_SIZE" => "30") do
+          expect(Defaults.pool_size).to eq(30)
+        end
+      end
+    end
+
+    describe ".pool_timeout" do
+      it "defaults to ENV['VAULT_POOL_TIMEOUT']" do
+        with_stubbed_env("VAULT_POOL_TIMEOUT" => "30.5") do
+          expect(Defaults.pool_timeout).to eq(30.5)
+        end
+      end
+    end
+
     describe ".proxy_address" do
       it "defaults to ENV['VAULT_PROXY_ADDRESS']" do
         with_stubbed_env("VAULT_PROXY_ADDRESS" => "30") do


### PR DESCRIPTION
Make the connection pool timeout (default is 0.5 secs) configurable, similar to how the connection pool size is configurable.