### PR TITLE
Add ability to specify a name for a cert to check for auth#tls

### DIFF
--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -287,11 +287,13 @@ module Vault
     #   The path to the auth backend to use for the login procedure.
     #
     # @return [Secret]
-    def tls(pem = nil, path = 'cert')
+    def tls(pem = nil, path = 'cert', name: nil)
       new_client = client.dup
       new_client.ssl_pem_contents = pem if !pem.nil?
 
-      json = new_client.post("/v1/auth/#{CGI.escape(path)}/login")
+      opts = {}
+      opts[:name] = name if name
+      json = new_client.post("/v1/auth/#{CGI.escape(path)}/login", opts)
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -286,6 +286,9 @@ module Vault
     # @param [String] path (default: 'cert')
     #   The path to the auth backend to use for the login procedure.
     #
+    # @param [String] name optional
+    #   The named certificate role provided to the login request. 
+    #
     # @return [Secret]
     def tls(pem = nil, path = 'cert', name: nil)
       new_client = client.dup

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -202,6 +202,13 @@ module Vault
         expect(subject.token).to eq(result.auth.client_token)
       end
 
+      it "returns nil if a certificate name is provided that doesn't exist" do
+        pending "dev server does not support tls"
+        secret = subject.auth.tls(auth_cert, name: "not_here")
+        
+        expect(secret).to_be nil
+      end
+
       it "raises an error if the authentication is bad", vault: "> 0.6.1" do
         subject.sys.disable_auth("cert")
 


### PR DESCRIPTION
This pull request seeks to add the ability to specify a certificate name when attempting TLS auth. This will bring the behavior more in line to the API specified here: https://www.vaultproject.io/api/auth/cert#login-with-tls-certificate-method