### PR TITLE
Adds KV PATCH support via 'update' methods.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,8 +71,8 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+.*/
           matrix:
             parameters:
-              ruby-version: ["2.7.1", "2.6", "2.5"]
-              vault-version: ["1.5.0", "1.4.2", "1.4.1", "1.4.0", "1.3.6"]
+              ruby-version: ["2.7.4", "2.7.1", "2.6", "2.5"]
+              vault-version: ["1.9.2", "1.5.0", "1.4.2", "1.4.1", "1.4.0", "1.3.6"]
           name: test-ruby-<< matrix.ruby-version >>-vault-<< matrix.vault-version >>
       - build-release:
           requires:

--- a/lib/vault/api/kv.rb
+++ b/lib/vault/api/kv.rb
@@ -122,6 +122,32 @@ module Vault
       true
     end
 
+    # Update the secret at the given path with the given data. Note that the
+    # data must be a {Hash}! Data will be merged with existing values.
+    #
+    # Note: This will raise an error if used on KV Secrets Engine Version 1.
+    #
+    # @example
+    #   Vault.kv.write("secret/multiple", password: "secret") #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] path
+    #   the path to update
+    # @param [Hash] data
+    #   the data to merge
+    #
+    # @return [Secret]
+    def update(path, data = {}, options = {})
+      headers = extract_headers!(options)
+      headers["Content-Type"] = "application/merge-patch+json"
+      json = client.patch("/v1/#{mount}/data/#{encode_path(path)}", JSON.fast_generate(:data => data), headers)
+      if json.nil?
+        return true
+      else
+        return Secret.decode(json)
+      end
+    end
+
+
     # Delete the secret at the given path. If the secret does not exist, vault
     # will still return true.
     #

--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -73,6 +73,32 @@ module Vault
       end
     end
 
+    # Update the secret at the given path with the given data. Note that the
+    # data must be a {Hash}! Data will be merged with existing values.
+    #
+    # Note: This will raise an error if used on KV Secrets Engine Version 1.
+    # Note: The path must include `data` to work properly for Version 2.
+    #
+    # @example
+    #   Vault.logical.update("secret/data/multiple", password: "secret") #=> #<Vault::Secret lease_id="">
+    #
+    # @param [String] path
+    #   the path to write
+    # @param [Hash] data
+    #   the data to write
+    #
+    # @return [Secret]
+    def update(path, data = {}, options = {})
+      headers = extract_headers!(options)
+      headers["Content-Type"] = "application/merge-patch+json"
+      json = client.patch("/v1/#{encode_path(path)}", JSON.fast_generate(data), headers)
+      if json.nil?
+        return true
+      else
+        return Secret.decode(json)
+      end
+    end
+
     # Delete the secret at the given path. If the secret does not exist, vault
     # will still return true.
     #


### PR DESCRIPTION
This adds an `update` method to `KV` to allow for patching paths as described here:
https://www.vaultproject.io/api-docs/secret/kv/kv-v2#patch-secret

It also adds an `update` method to `Logical` to allow for patching paths as well.  I did this for parity, but I'm not entirely sold on it as versioning requires the path start with `data` which the KV class does automatically, but Logical does not. I could easily be talked into removing that from this PR.