### PR TITLE
[VAULT-5411] Add handling of 412 errors to with_retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v?.??.? (Unreleased)
 
+## v0.17.0 (May 11, 2022)
+
+IMPROVEMENTS
+
+- Added MissingRequiredStateErr error type to refer to 412s returned by Vault 1.10 when the WAL index on the node does not match the index in the Server-Side Consistent Token. This error type can be passed as a parameter to `#with_retries`, and will also be retried automatically when `#with_retries` is used with no parameters.
+
 ## v0.16.0 (March 17, 2021)
 
 IMPROVEMENTS

--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -296,6 +296,8 @@ module Vault
           request(verb, response[LOCATION_HEADER], data, headers)
         when Net::HTTPSuccess
           success(response)
+        when Net::HTTPPreconditionFailed
+          raise MissingRequiredStateError.new
         else
           error(response)
         end

--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -296,8 +296,6 @@ module Vault
           request(verb, response[LOCATION_HEADER], data, headers)
         when Net::HTTPSuccess
           success(response)
-        when Net::HTTPPreconditionFailed
-          raise MissingRequiredStateError.new
         else
           error(response)
         end
@@ -394,6 +392,8 @@ module Vault
 
       # Use the correct exception class
       case response
+      when Net::HTTPPreconditionFailed
+        raise MissingRequiredStateError.new
       when Net::HTTPClientError
         klass = HTTPClientError
       when Net::HTTPServerError

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -35,7 +35,7 @@ module Vault
 
     # The set of exceptions that are detect and retried by default
     # with `with_retries`
-    RETRIED_EXCEPTIONS = [HTTPServerError]
+    RETRIED_EXCEPTIONS = [HTTPServerError, MissingRequiredStateError]
 
     class << self
       # The list of calculated options for this configurable.

--- a/lib/vault/errors.rb
+++ b/lib/vault/errors.rb
@@ -22,6 +22,19 @@ EOH
     end
   end
 
+  class MissingRequiredStateError < VaultError
+    def initialize
+      super <<-EOH
+The performance standby node does not yet have the 
+most recent index state required to authenticate 
+the request.
+
+The request should be retried with the with_retries clause.
+
+EOH
+    end
+  end
+
   class HTTPConnectionError < VaultError
     attr_reader :address
 

--- a/lib/vault/errors.rb
+++ b/lib/vault/errors.rb
@@ -29,8 +29,7 @@ The performance standby node does not yet have the
 most recent index state required to authenticate 
 the request.
 
-The request should be retried with the with_retries clause.
-
+Generally, the request should be retried with the with_retries clause.
 EOH
     end
   end

--- a/lib/vault/version.rb
+++ b/lib/vault/version.rb
@@ -1,3 +1,3 @@
 module Vault
-  VERSION = "0.16.0"
+  VERSION = "0.17.0"
 end


### PR DESCRIPTION
Now that Vault 1.10 supports [server-side consistent tokens](https://www.vaultproject.io/docs/faq/ssct), clients need to be able to retry on the 412 error that is returned when the index state on the token does not match what's on the performance standby node.

I named the new error type similarly to how it is named in our Go library.

I also added this error type to the default list of retried exceptions, to be more aligned with the Go library, which automatically retries on 412s.