### PR TITLE
Support IPv6 URIs

### DIFF
--- a/lib/vault/persistent.rb
+++ b/lib/vault/persistent.rb
@@ -603,10 +603,10 @@ class PersistentHTTP
   def connection_for uri
     use_ssl = uri.scheme.downcase == 'https'
 
-    net_http_args = [uri.host, uri.port]
+    net_http_args = [uri.hostname, uri.port]
 
     net_http_args.concat @proxy_args if
-      @proxy_uri and not proxy_bypass? uri.host, uri.port
+      @proxy_uri and not proxy_bypass? uri.hostname, uri.port
 
     connection = @pool.checkout net_http_args
 
@@ -715,7 +715,7 @@ class PersistentHTTP
   # Returns the HTTP protocol version for +uri+
 
   def http_version uri
-    @http_versions["#{uri.host}:#{uri.port}"]
+    @http_versions["#{uri.hostname}:#{uri.port}"]
   end
 
   ##
@@ -798,7 +798,7 @@ class PersistentHTTP
 
     if @proxy_uri then
       @proxy_args = [
-        @proxy_uri.host,
+        @proxy_uri.hostname,
         @proxy_uri.port,
         unescape(@proxy_uri.user),
         unescape(@proxy_uri.password),
@@ -973,7 +973,7 @@ class PersistentHTTP
       end
     end
 
-    @http_versions["#{uri.host}:#{uri.port}"] ||= response.http_version
+    @http_versions["#{uri.hostname}:#{uri.port}"] ||= response.http_version
 
     response
   end


### PR DESCRIPTION
Fixes #248 by changing `uri.host` to `uri.hostname` in `Vault::PersistentHTTP`.

The underlying issue is that [`URI#host`](https://ruby-doc.org/stdlib/libdoc/uri/rdoc/URI/Generic.html#host) is the incorrect method to use for passing a hostname to `Net::HTTP`, because it doesn't handle IPv6 addresses correctly:

> Since IPv6 addresses are wrapped with brackets in URIs, this method returns IPv6 addresses wrapped with brackets. This form is not appropriate to pass to socket methods such as `TCPSocket.open`. If unwrapped host names are required, use the [`hostname`](https://ruby-doc.org/stdlib/libdoc/uri/rdoc/URI/Generic.html#method-i-hostname) method.

Note: this module appears to be vendored from [`drbrain/net-http-persistent`](https://github.com/drbrain/net-http-persistent), which already included a fix for this issue (https://github.com/drbrain/net-http-persistent/pull/76, https://github.com/drbrain/net-http-persistent/pull/82, https://github.com/drbrain/net-http-persistent/commit/aa112b27d435e21c978f8274fe72d259db93aa2d) in its latest release.