### PR TITLE
Added configuration option `Vault.allowed_proxy_addresses`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## v?.??.? (Unreleased)
 
+IMPROVEMENTS
+
+- Added configuration option `Vault.allowed_proxy_addresses` so a proxy can be specified even with an HTTPS connection.
+
 ## v0.17.0 (May 11, 2022)
 
 IMPROVEMENTS

--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -246,7 +246,7 @@ module Vault
         request.basic_auth uri.user, uri.password
       end
 
-      if proxy_address and uri.scheme.downcase == "https"
+      if proxy_address and uri.scheme.downcase == "https" and ! allowed_proxy_addresses.includes?(proxy_address)
         raise SecurityError, "no direct https connection to vault"
       end
 

--- a/lib/vault/configurable.rb
+++ b/lib/vault/configurable.rb
@@ -9,6 +9,7 @@ module Vault
         :hostname,
         :namespace,
         :open_timeout,
+        :allowed_proxy_addresses,
         :proxy_address,
         :proxy_password,
         :proxy_port,

--- a/lib/vault/defaults.rb
+++ b/lib/vault/defaults.rb
@@ -104,6 +104,14 @@ module Vault
         end
       end
 
+      # HTTP Proxy server addresses to allow even if HTTPS is being used.
+      # If this set is empty, the Vault URL uses HTTPS, and a proxy is specified,
+      # an error will occur.
+      # @return [Array, nil]
+      def allowed_proxy_addresses
+        []
+      end
+
       # The HTTP Proxy server address as a string
       # @return [String, nil]
       def proxy_address

--- a/spec/unit/defaults_spec.rb
+++ b/spec/unit/defaults_spec.rb
@@ -101,6 +101,12 @@ module Vault
       end
     end
 
+    describe ".allowed_proxy_addresses" do
+      it "defaults to an empty set" do
+        expect(Defaults.allowed_proxy_addresses).to eq([])
+      end
+    end
+
     describe ".proxy_address" do
       it "defaults to ENV['VAULT_PROXY_ADDRESS']" do
         with_stubbed_env("VAULT_PROXY_ADDRESS" => "30") do


### PR DESCRIPTION
This PR adds a configuration option `Vault.allowed_proxy_addresses`, an array of hostnames, to allow `vault-ruby` to use a proxy with an HTTPS connection.

Currently, `vault-ruby` explicitly refuses to connect if a proxy is configured and the Vault target is HTTPS:

https://github.com/hashicorp/vault-ruby/blob/42d21087b21da335e4ef15469c18755acc875910/lib/vault/client.rb#L249-L251

I presume (this code is several years old) this was intended as a partial protection against a MITM attack.  However, sometimes it's necessary to transit a proxy to reach Vault.  When HTTPS is used, the connection is still end-to-end protected; an HTTPS proxy does not unwrap the TLS stream.