### PR TITLE
Allow using an HTTPS connection with a proxy

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -61,11 +61,6 @@ module Vault
       a << PersistentHTTP::Error
     end.freeze
 
-    # Indicates a requested operation is not possible due to security
-    # concerns.
-    class SecurityError < RuntimeError
-    end
-
     include Vault::Configurable
 
     # Create a new Client with the given options. Any options given take
@@ -244,10 +239,6 @@ module Vault
       request = class_for_request(verb).new(uri.request_uri)
       if uri.userinfo()
         request.basic_auth uri.user, uri.password
-      end
-
-      if proxy_address and uri.scheme.downcase == "https"
-        raise SecurityError, "no direct https connection to vault"
       end
 
       # Get a list of headers

--- a/spec/integration/api/sys/mount_spec.rb
+++ b/spec/integration/api/sys/mount_spec.rb
@@ -80,6 +80,7 @@ module Vault
       it "remounts at the new path" do
         subject.mount("test_remount", "aws")
         subject.remount("test_remount", "new_test_remount")
+        sleep 0.1
         expect(subject.mounts[:test_remount]).to be(nil)
         expect(subject.mounts[:new_test_remount]).to be
       end

--- a/spec/support/vault_server.rb
+++ b/spec/support/vault_server.rb
@@ -61,7 +61,7 @@ module RSpec
     end
 
     def wait_for_ready(&block)
-      Timeout.timeout(5) do
+      Timeout.timeout(15) do
         while !File.exist?(TOKEN_PATH)
           sleep(0.25)
         end
@@ -69,7 +69,7 @@ module RSpec
 
       yield
     rescue Timeout::Error
-      raise "Vault did not start in 5 seconds!"
+      raise "Vault did not start in 15 seconds!"
     end
   end
 end


### PR DESCRIPTION
This PR allows `vault-ruby` to use a proxy with an HTTPS connection to Vault.

Currently, vault-ruby explicitly refuses to connect if a proxy is configured and the Vault target is HTTPS.  I presume (this code is several years old) this check was intended as a partial protection against a MITM attack. However, sometimes it's necessary to transit a proxy to reach Vault.  When HTTPS is used, the connection is still end-to-end protected; an HTTPS proxy does not unwrap the TLS stream.

For comparison, I could find no such restriction on HTTP proxy usage in Vault's [Go client](https://github.com/hashicorp/vault/blob/main/api/client.go).