### PR TITLE
optional mount path for approle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ IMPROVEMENTS
 
 - Added `cluster_address` field to `LeaderStatus` response from `sys/leader` endpoint [GH-204]
 - Updated AppRole `set_role` documentation to include modern parameters like `secret_id_bound_cidrs`, `token_bound_cidrs`, and `token_policies`. Added reference to official Vault API docs for complete parameter list. [GH-220]
+- Added support for custom mount paths in AppRole authentication via `mount:` option [GH-292]
 
 BUG FIXES
 

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -81,21 +81,32 @@ module Vault
     # successful, the resulting token will be stored on the client and used for
     # future requests.
     #
-    # @example
+    # @example Default mount point
     #   Vault.auth.approle(
     #     "db02de05-fa39-4855-059b-67221c5c2f63",
     #     "6a174c20-f6de-a53c-74d2-6018fcceff64",
     #   ) #=> #<Vault::Secret lease_id="">
     #
+    # @example Custom mount point
+    #   Vault.auth.approle(
+    #     "db02de05-fa39-4855-059b-67221c5c2f63",
+    #     "6a174c20-f6de-a53c-74d2-6018fcceff64",
+    #     mount: "my-approle"
+    #   ) #=> #<Vault::Secret lease_id="">
+    #
     # @param [String] role_id
     # @param [String] secret_id (default: nil)
     #   It is required when `bind_secret_id` is enabled for the specified role_id
+    # @param [Hash] options
+    # @option options [String] :mount (default: "approle")
+    #   The path where the approle auth backend is mounted
     #
     # @return [Secret]
-    def approle(role_id, secret_id=nil)
+    def approle(role_id, secret_id=nil, options = {})
+      mount = options[:mount] || 'approle'
       payload = { role_id: role_id }
       payload[:secret_id] = secret_id if secret_id
-      json = client.post("/v1/auth/approle/login", JSON.generate(payload))
+      json = client.post("/v1/auth/#{CGI.escape(mount)}/login", JSON.generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret


### PR DESCRIPTION
Actually the path for an approle is fixed in code:"/v1/auth/approle/login".
This PR add the possibility to support customizable path, for example, "/v1/auth/my_approle/login"