### PR TITLE
[TF-2716] Tighten up regex match ID'd by GitHub code scanning

### DIFF
--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -316,7 +316,7 @@ module Vault
     #
     # @return [String] aws region
     def region_from_sts_endpoint(sts_endpoint)
-      valid_sts_endpoint = %r{https:\/\/sts\.?(.*).amazonaws.com}.match(sts_endpoint)
+      valid_sts_endpoint = %r{https:\/\/sts\.?(.*)\.amazonaws.com}.match(sts_endpoint)
       raise "Unable to parse STS endpoint #{sts_endpoint}" unless valid_sts_endpoint
       valid_sts_endpoint[1].empty? ? 'us-east-1' : valid_sts_endpoint[1]
     end

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -316,7 +316,7 @@ module Vault
     #
     # @return [String] aws region
     def region_from_sts_endpoint(sts_endpoint)
-      valid_sts_endpoint = %r{https:\/\/sts\.?(.*)\.amazonaws.com}.match(sts_endpoint)
+      valid_sts_endpoint = %r{https:\/\/sts\.?(.*)\.amazonaws\.com}.match(sts_endpoint)
       raise "Unable to parse STS endpoint #{sts_endpoint}" unless valid_sts_endpoint
       valid_sts_endpoint[1].empty? ? 'us-east-1' : valid_sts_endpoint[1]
     end

--- a/spec/unit/auth_spec.rb
+++ b/spec/unit/auth_spec.rb
@@ -28,6 +28,11 @@ module Vault
         let(:sts_endpoint) { "https:sts.amazonaws.com" }
         it { expect { subject }.to raise_exception(StandardError, "Unable to parse STS endpoint https:sts.amazonaws.com") }
       end
+
+      context 'with a potentially malicious url' do
+        let(:sts_endpoint) { "https://stsXamazonaws.com" }
+        it { expect {subject}.to raise_exception(StandardError, "Unable to parse STS endpoint https://stsXamazonaws.com") }
+      end
     end
   end
 end


### PR DESCRIPTION
Addresses https://github.com/hashicorp/vault-ruby/security/code-scanning/1 for [TF-2716](https://hashicorp.atlassian.net/browse/TF-2716).

[TF-2716]: https://hashicorp.atlassian.net/browse/TF-2716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ