### PR TITLE
TF-8697: Support Ruby versions lacking OpenSSL constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## v?.??.? (Unreleased)
 
+## v0.18.1 (September 14, 2023)
+
+BUG FIXES
+
+- Restored the ability to use this gem with older Ruby versions that do not have
+  the `OpenSSL::SSL::TLS1_2_VERSION` constant.
+
 ## v0.18.0 (September 14, 2023)
 
 IMPROVEMENTS

--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -64,6 +64,13 @@ module Vault
       a << PersistentHTTP::Error
     end.freeze
 
+    # Vault requires at least TLS1.2
+    MIN_TLS_VERSION = if defined? OpenSSL::SSL::TLS1_2_VERSION
+                        OpenSSL::SSL::TLS1_2_VERSION
+                      else
+                        "TLSv1_2"
+                      end
+
     include Vault::Configurable
 
     # Create a new Client with the given options. Any options given take
@@ -112,8 +119,7 @@ module Vault
 
         @nhp.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
-        # Vault requires at least TLS1.2
-        @nhp.min_version = OpenSSL::SSL::TLS1_2_VERSION
+        @nhp.min_version = MIN_TLS_VERSION
 
         # Only use secure ciphers
         @nhp.ciphers = ssl_ciphers

--- a/lib/vault/persistent.rb
+++ b/lib/vault/persistent.rb
@@ -1043,7 +1043,15 @@ class PersistentHTTP
     connection.use_ssl = true
 
     connection.ciphers     = @ciphers     if @ciphers
-    connection.min_version = @min_version if @min_version
+
+    if @min_version
+      if connection.respond_to? :min_version=
+        connection.min_version = @min_version
+      else
+        connection.ssl_version = @min_version
+      end
+    end
+
     connection.ssl_timeout = @ssl_timeout if @ssl_timeout
 
     connection.verify_depth = @verify_depth

--- a/lib/vault/version.rb
+++ b/lib/vault/version.rb
@@ -2,5 +2,5 @@
 # SPDX-License-Identifier: MPL-2.0
 
 module Vault
-  VERSION = "0.18.0"
+  VERSION = "0.18.1"
 end


### PR DESCRIPTION
Closes #299

This pull request restores support for older Ruby versions such as Ruby 2.3 that do not have the `OpenSSL::SSL:TLS1_2_VERSION` constant, which was introduced in Ruby 2.5.

While these versions of Ruby are end-of-life, they do still appear in usage in things like embedded Chef. It's not a big change to restore functionality, so we've done that.