### PR TITLE
lock aws-sdk gems to support EOL ruby versions

### DIFF
--- a/vault.gemspec
+++ b/vault.gemspec
@@ -21,7 +21,12 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.0"
-  spec.add_runtime_dependency "aws-sigv4"
+  if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.4.0")
+    spec.add_runtime_dependency "aws-sigv4", "= 1.6.0"
+    spec.add_runtime_dependency "aws-eventstream", "= 1.2.0"
+  else
+    spec.add_runtime_dependency "aws-sigv4"
+  end
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "pry",     "~> 0.13.1"


### PR DESCRIPTION
Fixes [#313](https://github.com/hashicorp/vault-ruby/issues/313).

In order to support the Ruby version 2.3 and 2.4 in vault-ruby gem, the aws-sdk gems need to be locked to older versions where these EOL ruby versions are still supported.