### PR TITLE
http client's shutdown should be lock-protected

### DIFF
--- a/lib/vault/client.rb
+++ b/lib/vault/client.rb
@@ -164,8 +164,10 @@ module Vault
 
     # Shutdown any open pool connections. Pool will be recreated upon next request.
     def shutdown
-      @nhp.shutdown()
-      @nhp = nil
+      @lock.synchronize do
+        @nhp.shutdown()
+        @nhp = nil
+      end
     end
 
     # Creates and yields a new client object with the given token. This may be


### PR DESCRIPTION
since `@nhp` is modified within the mutex-protected area, so all its accesses should also be mutex-protected