### PR TITLE
Escape hyphen in encoding regex

### DIFF
--- a/lib/vault/encode.rb
+++ b/lib/vault/encode.rb
@@ -12,7 +12,7 @@ module Vault
     #
     # @return [String]
     def encode_path(path)
-      path.b.gsub(%r!([^a-zA-Z0-9_.-/]+)!) { |m|
+      path.b.gsub(%r!([^a-zA-Z0-9_.\-/]+)!) { |m|
         '%' + m.unpack('H2' * m.bytesize).join('%').upcase
       }
     end


### PR DESCRIPTION
I'm not sure if it's intended or not, but I believe the hyphen should be escaped. Otherwise, hyphens in the key name will be encoded, resulting in a wrong key name.