### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         # https://endoflife.date/ruby
-        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        ruby: ["3.1", "3.2", "3.3", "3.4"]
         vault: ["1.11.9", "1.12.5", "1.13.1"]
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         # https://endoflife.date/ruby
         ruby: ["3.1", "3.2", "3.3", "3.4"]
-        vault: ["1.11.9", "1.12.5", "1.13.1"]
+        vault: ["1.14.10", "1.15.6", "1.16.3", "1.17.6", "1.18.4"]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: ruby/setup-ruby@22fdc77bf4148f810455b226c90fb81b5cbc00a7 # v1.171.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # v1.221.0
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 3.1"
   spec.add_runtime_dependency "aws-sigv4"
+  spec.add_runtime_dependency "base64"
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "pry",     "~> 0.13.1"

--- a/vault.gemspec
+++ b/vault.gemspec
@@ -20,13 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.0"
-  if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.4.0")
-    spec.add_runtime_dependency "aws-sigv4", "= 1.6.0"
-    spec.add_runtime_dependency "aws-eventstream", "= 1.2.0"
-  else
-    spec.add_runtime_dependency "aws-sigv4"
-  end
+  spec.required_ruby_version = ">= 3.1"
+  spec.add_runtime_dependency "aws-sigv4"
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "pry",     "~> 0.13.1"


### PR DESCRIPTION
This is a prerequisite for #345, so CI will pass.

* minimum ruby was set to match ruby's EOL.
* the CI matrix was updated to reflect more recent ruby and vault versions
* base64 was added as an explicit dependency, for ruby 3.4
