### PR TITLE
Pin dependency versions for Ruby <2.7

### DIFF
--- a/vault.gemspec
+++ b/vault.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |spec|
   if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.4.0")
     spec.add_runtime_dependency "aws-sigv4", "= 1.6.0"
     spec.add_runtime_dependency "aws-eventstream", "= 1.2.0"
+  elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7.0")
+    spec.add_runtime_dependency "aws-sigv4", "= 1.11.0"
+    spec.add_runtime_dependency "aws-eventstream", "= 1.3.2"
   else
     spec.add_runtime_dependency "aws-sigv4"
   end


### PR DESCRIPTION
This change pins the versions of `aws-sigv4` and `aws-eventstream` used with Ruby <2.7. AWS [recently dropped support](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sigv4/CHANGELOG.md#1120-2025-06-02) for Ruby 2.5/2.6 and because there is [no version pinning for `aws-sigv4` in the gemspec](https://github.com/hashicorp/vault-ruby/blob/master/vault.gemspec#L28) otherwise, it tries to download the latest version which is incompatible with these older versions of Ruby. 

Without this change, installations fail with something similar to the following:

```
---- Begin output of /opt/chef/embedded/bin/gem install vault -q --no-rdoc --no-ri -v "0.18.2" --source=https://www.rubygems.org ----
STDOUT:
STDERR: ERROR:  Error installing vault:
The last version of aws-eventstream (~> 1, >= 1.0.2) to support your Ruby & RubyGems was 1.3.2. Try installing it with `gem install aws-eventstream -v 1.3.2` and then running the current command again
aws-eventstream requires Ruby version >= 2.7. The current ruby version is 2.5.0.
---- End output of /opt/chef/embedded/bin/gem install vault -q --no-rdoc --no-ri -v "0.18.2" --source=https://www.rubygems.org ----
Ran /opt/chef/embedded/bin/gem install vault -q --no-rdoc --no-ri -v "0.18.2" --source=https://www.rubygems.org returned 1
```