### PR TITLE
Lock AWS gems for Ruby 2.5 - 2.6

### DIFF
--- a/vault.gemspec
+++ b/vault.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |spec|
   if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.4.0")
     spec.add_runtime_dependency "aws-sigv4", "= 1.6.0"
     spec.add_runtime_dependency "aws-eventstream", "= 1.2.0"
+  elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.7.0")
+    spec.add_runtime_dependency "aws-sigv4", "= 1.11.0"
+    spec.add_runtime_dependency "aws-eventstream", "= 1.3.2"
   else
     spec.add_runtime_dependency "aws-sigv4"
   end


### PR DESCRIPTION
aws-sigv4 and aws-eventstream now require Ruby 2.7. If you use Ruby 2.5 or 2.6, the AWS gems need to be locked.

This is similar to what was done in https://github.com/hashicorp/vault-ruby/pull/314.
