### PR TITLE
Replace deprecated `JSON.fast_generate`

### DIFF
--- a/lib/vault/api/approle.rb
+++ b/lib/vault/api/approle.rb
@@ -61,7 +61,7 @@ module Vault
     # @return [true]
     def set_role(name, options = {})
       headers = extract_headers!(options)
-      client.post("/v1/auth/approle/role/#{encode_path(name)}", JSON.fast_generate(options), headers)
+      client.post("/v1/auth/approle/role/#{encode_path(name)}", JSON.generate(options), headers)
       return true
     end
 
@@ -118,7 +118,7 @@ module Vault
     # @return [true]
     def set_role_id(name, role_id)
       options = { role_id: role_id }
-      client.post("/v1/auth/approle/role/#{encode_path(name)}/role-id", JSON.fast_generate(options))
+      client.post("/v1/auth/approle/role/#{encode_path(name)}/role-id", JSON.generate(options))
       return true
     end
 
@@ -163,9 +163,9 @@ module Vault
     def create_secret_id(role_name, options = {})
       headers = extract_headers!(options)
       if options[:secret_id]
-        json = client.post("/v1/auth/approle/role/#{encode_path(role_name)}/custom-secret-id", JSON.fast_generate(options), headers)
+        json = client.post("/v1/auth/approle/role/#{encode_path(role_name)}/custom-secret-id", JSON.generate(options), headers)
       else
-        json = client.post("/v1/auth/approle/role/#{encode_path(role_name)}/secret-id", JSON.fast_generate(options), headers)
+        json = client.post("/v1/auth/approle/role/#{encode_path(role_name)}/secret-id", JSON.generate(options), headers)
       end
       return Secret.decode(json)
     end
@@ -184,7 +184,7 @@ module Vault
     # @return [Secret, nil]
     def secret_id(role_name, secret_id)
       opts = { secret_id: secret_id }
-      json = client.post("/v1/auth/approle/role/#{encode_path(role_name)}/secret-id/lookup", JSON.fast_generate(opts), {})
+      json = client.post("/v1/auth/approle/role/#{encode_path(role_name)}/secret-id/lookup", JSON.generate(opts), {})
       return nil unless json
       return Secret.decode(json)
     rescue HTTPError => e

--- a/lib/vault/api/auth.rb
+++ b/lib/vault/api/auth.rb
@@ -71,7 +71,7 @@ module Vault
     # @return [Secret]
     def app_id(app_id, user_id, options = {})
       payload = { app_id: app_id, user_id: user_id }.merge(options)
-      json = client.post("/v1/auth/app-id/login", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/app-id/login", JSON.generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -95,7 +95,7 @@ module Vault
     def approle(role_id, secret_id=nil)
       payload = { role_id: role_id }
       payload[:secret_id] = secret_id if secret_id
-      json = client.post("/v1/auth/approle/login", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/approle/login", JSON.generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -120,7 +120,7 @@ module Vault
     # @return [Secret]
     def userpass(username, password, options = {})
       payload = { password: password }.merge(options)
-      json = client.post("/v1/auth/userpass/login/#{encode_path(username)}", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/userpass/login/#{encode_path(username)}", JSON.generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -142,7 +142,7 @@ module Vault
     # @return [Secret]
     def ldap(username, password, options = {})
       payload = { password: password }.merge(options)
-      json = client.post("/v1/auth/ldap/login/#{encode_path(username)}", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/ldap/login/#{encode_path(username)}", JSON.generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -160,7 +160,7 @@ module Vault
     # @return [Secret]
     def github(github_token, path="/v1/auth/github/login")
       payload = {token: github_token}
-      json = client.post(path, JSON.fast_generate(payload))
+      json = client.post(path, JSON.generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -185,7 +185,7 @@ module Vault
       payload = { role: role, pkcs7: pkcs7 }
       # Set a custom nonce if client is providing one
       payload[:nonce] = nonce if nonce
-      json = client.post(route, JSON.fast_generate(payload))
+      json = client.post(route, JSON.generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -242,7 +242,7 @@ module Vault
         iam_request_body: Base64.strict_encode64(request_body)
       }
 
-      json = client.post(route, JSON.fast_generate(payload))
+      json = client.post(route, JSON.generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret
@@ -264,7 +264,7 @@ module Vault
     # @return [Secret]
     def gcp(role, jwt, path = 'gcp')
       payload = { role: role, jwt: jwt }
-      json = client.post("/v1/auth/#{CGI.escape(path)}/login", JSON.fast_generate(payload))
+      json = client.post("/v1/auth/#{CGI.escape(path)}/login", JSON.generate(payload))
       secret = Secret.decode(json)
       client.token = secret.auth.client_token
       return secret

--- a/lib/vault/api/auth_tls.rb
+++ b/lib/vault/api/auth_tls.rb
@@ -45,7 +45,7 @@ module Vault
     # @return [true]
     def set_certificate(name, options = {})
       headers = extract_headers!(options)
-      client.post("/v1/auth/cert/certs/#{encode_path(name)}", JSON.fast_generate(options), headers)
+      client.post("/v1/auth/cert/certs/#{encode_path(name)}", JSON.generate(options), headers)
       return true
     end
 

--- a/lib/vault/api/auth_token.rb
+++ b/lib/vault/api/auth_token.rb
@@ -69,7 +69,7 @@ module Vault
     # @return [Secret]
     def create(options = {})
       headers = extract_headers!(options)
-      json = client.post("/v1/auth/token/create", JSON.fast_generate(options), headers)
+      json = client.post("/v1/auth/token/create", JSON.generate(options), headers)
       return Secret.decode(json)
     end
 
@@ -84,7 +84,7 @@ module Vault
     # @return [Secret]
     def create_orphan(options = {})
       headers = extract_headers!(options)
-      json = client.post("/v1/auth/token/create-orphan", JSON.fast_generate(options), headers)
+      json = client.post("/v1/auth/token/create-orphan", JSON.generate(options), headers)
       return Secret.decode(json)
     end
 
@@ -98,7 +98,7 @@ module Vault
     # @return [Secret]
     def create_with_role(name, options = {})
       headers = extract_headers!(options)
-      json = client.post("/v1/auth/token/create/#{encode_path(name)}", JSON.fast_generate(options), headers)
+      json = client.post("/v1/auth/token/create/#{encode_path(name)}", JSON.generate(options), headers)
       return Secret.decode(json)
     end
 
@@ -113,7 +113,7 @@ module Vault
     # @return [Secret]
     def lookup(token, options = {})
       headers = extract_headers!(options)
-      json = client.post("/v1/auth/token/lookup", JSON.fast_generate(
+      json = client.post("/v1/auth/token/lookup", JSON.generate(
         token: token,
       ), headers)
       return Secret.decode(json)
@@ -128,7 +128,7 @@ module Vault
     # @param [Hash] options
     def lookup_accessor(accessor, options = {})
       headers = extract_headers!(options)
-      json = client.post("/v1/auth/token/lookup-accessor", JSON.fast_generate(
+      json = client.post("/v1/auth/token/lookup-accessor", JSON.generate(
         accessor: accessor,
       ), headers)
       return Secret.decode(json)
@@ -157,7 +157,7 @@ module Vault
     # @return [Secret]
     def renew(token, increment = 0, options = {})
       headers = extract_headers!(options)
-      json = client.put("/v1/auth/token/renew", JSON.fast_generate(
+      json = client.put("/v1/auth/token/renew", JSON.generate(
         token: token,
         increment: increment,
       ), headers)
@@ -174,7 +174,7 @@ module Vault
     # @return [Secret]
     def renew_self(increment = 0, options = {})
       headers = extract_headers!(options)
-      json = client.put("/v1/auth/token/renew-self", JSON.fast_generate(
+      json = client.put("/v1/auth/token/renew-self", JSON.generate(
         increment: increment,
       ), headers)
       return Secret.decode(json)
@@ -201,7 +201,7 @@ module Vault
     # @return [true]
     def revoke_orphan(token, options = {})
       headers = extract_headers!(options)
-      client.put("/v1/auth/token/revoke-orphan", JSON.fast_generate(
+      client.put("/v1/auth/token/revoke-orphan", JSON.generate(
         token: token,
       ), headers)
       return true
@@ -218,7 +218,7 @@ module Vault
     # @return [true]
     def revoke_accessor(accessor, options = {})
       headers = extract_headers!(options)
-      client.put("/v1/auth/token/revoke-accessor", JSON.fast_generate(
+      client.put("/v1/auth/token/revoke-accessor", JSON.generate(
         accessor: accessor,
       ), headers)
       return true
@@ -235,7 +235,7 @@ module Vault
     # @return [true]
     def revoke(token, options = {})
       headers = extract_headers!(options)
-      client.put("/v1/auth/token/revoke", JSON.fast_generate(
+      client.put("/v1/auth/token/revoke", JSON.generate(
         token: token,
       ), headers)
       return true

--- a/lib/vault/api/kv.rb
+++ b/lib/vault/api/kv.rb
@@ -99,7 +99,7 @@ module Vault
     # @return [Secret]
     def write(path, data = {}, options = {})
       headers = extract_headers!(options)
-      json = client.post("/v1/#{mount}/data/#{encode_path(path)}", JSON.fast_generate(:data => data), headers)
+      json = client.post("/v1/#{mount}/data/#{encode_path(path)}", JSON.generate(:data => data), headers)
       if json.nil?
         return true
       else
@@ -120,7 +120,7 @@ module Vault
     #
     # @return [true]
     def write_metadata(path, metadata = {})
-      client.post("/v1/#{mount}/metadata/#{encode_path(path)}", JSON.fast_generate(metadata))
+      client.post("/v1/#{mount}/metadata/#{encode_path(path)}", JSON.generate(metadata))
 
       true
     end
@@ -140,7 +140,7 @@ module Vault
     def patch_metadata(path, metadata = {}, options = {})
       headers = extract_headers!(options)
       headers["Content-Type"] = "application/merge-patch+json"
-      client.patch("/v1/#{mount}/metadata/#{encode_path(path)}", JSON.fast_generate(metadata), headers)
+      client.patch("/v1/#{mount}/metadata/#{encode_path(path)}", JSON.generate(metadata), headers)
 
       true
     end
@@ -173,7 +173,7 @@ module Vault
     #
     # @return [true]
     def delete_versions(path, versions)
-      client.post("/v1/#{mount}/delete/#{encode_path(path)}", JSON.fast_generate(versions: versions))
+      client.post("/v1/#{mount}/delete/#{encode_path(path)}", JSON.generate(versions: versions))
 
       true
     end
@@ -190,7 +190,7 @@ module Vault
     #
     # @return [true]
     def undelete_versions(path, versions)
-      client.post("/v1/#{mount}/undelete/#{encode_path(path)}", JSON.fast_generate(versions: versions))
+      client.post("/v1/#{mount}/undelete/#{encode_path(path)}", JSON.generate(versions: versions))
 
       true
     end
@@ -222,7 +222,7 @@ module Vault
     #
     # @return [true]
     def destroy_versions(path, versions)
-      client.post("/v1/#{mount}/destroy/#{encode_path(path)}", JSON.fast_generate(versions: versions))
+      client.post("/v1/#{mount}/destroy/#{encode_path(path)}", JSON.generate(versions: versions))
 
       true
     end

--- a/lib/vault/api/logical.rb
+++ b/lib/vault/api/logical.rb
@@ -68,7 +68,7 @@ module Vault
     # @return [Secret]
     def write(path, data = {}, options = {})
       headers = extract_headers!(options)
-      json = client.put("/v1/#{encode_path(path)}", JSON.fast_generate(data), headers)
+      json = client.put("/v1/#{encode_path(path)}", JSON.generate(data), headers)
       if json.nil?
         return true
       else

--- a/lib/vault/api/sys/audit.rb
+++ b/lib/vault/api/sys/audit.rb
@@ -54,7 +54,7 @@ module Vault
     #
     # @return [true]
     def enable_audit(path, type, description, options = {})
-      client.put("/v1/sys/audit/#{encode_path(path)}", JSON.fast_generate(
+      client.put("/v1/sys/audit/#{encode_path(path)}", JSON.generate(
         type:        type,
         description: description,
         options:     options,
@@ -86,7 +86,7 @@ module Vault
     #
     # @return [String]
     def audit_hash(path, input)
-      json = client.post("/v1/sys/audit-hash/#{encode_path(path)}", JSON.fast_generate(input: input))
+      json = client.post("/v1/sys/audit-hash/#{encode_path(path)}", JSON.generate(input: input))
       json = json[:data] if json[:data]
       json[:hash]
     end

--- a/lib/vault/api/sys/auth.rb
+++ b/lib/vault/api/sys/auth.rb
@@ -60,7 +60,7 @@ module Vault
       payload = { type: type }
       payload[:description] = description if !description.nil?
 
-      client.post("/v1/sys/auth/#{encode_path(path)}", JSON.fast_generate(payload))
+      client.post("/v1/sys/auth/#{encode_path(path)}", JSON.generate(payload))
       return true
     end
 
@@ -108,7 +108,7 @@ module Vault
     # @return [AuthConfig]
     #   configuration of the given auth path
     def put_auth_tune(path, config = {})
-      json = client.put("/v1/sys/auth/#{encode_path(path)}/tune", JSON.fast_generate(config))
+      json = client.put("/v1/sys/auth/#{encode_path(path)}/tune", JSON.generate(config))
       if json.nil?
         return true
       else

--- a/lib/vault/api/sys/init.rb
+++ b/lib/vault/api/sys/init.rb
@@ -70,7 +70,7 @@ module Vault
     #
     # @return [InitResponse]
     def init(options = {})
-      json = client.put("/v1/sys/init", JSON.fast_generate(
+      json = client.put("/v1/sys/init", JSON.generate(
         root_token_pgp_key: options.fetch(:root_token_pgp_key, nil),
         secret_shares:      options.fetch(:secret_shares, options.fetch(:shares, 5)),
         secret_threshold:   options.fetch(:secret_threshold, options.fetch(:threshold, 3)),

--- a/lib/vault/api/sys/lease.rb
+++ b/lib/vault/api/sys/lease.rb
@@ -14,7 +14,7 @@ module Vault
     #
     # @return [Secret]
     def renew(id, increment = 0)
-      json = client.put("/v1/sys/renew/#{id}", JSON.fast_generate(
+      json = client.put("/v1/sys/renew/#{id}", JSON.generate(
         increment: increment,
       ))
       return Secret.decode(json)

--- a/lib/vault/api/sys/mount.rb
+++ b/lib/vault/api/sys/mount.rb
@@ -98,7 +98,7 @@ module Vault
       payload = options.merge type: type
       payload[:description] = description if !description.nil?
 
-      client.post("/v1/sys/mounts/#{encode_path(path)}", JSON.fast_generate(payload))
+      client.post("/v1/sys/mounts/#{encode_path(path)}", JSON.generate(payload))
       return true
     end
 
@@ -124,7 +124,7 @@ module Vault
     # @param [Hash] data
     #   the data to write
     def mount_tune(path, data = {})
-      json = client.post("/v1/sys/mounts/#{encode_path(path)}/tune", JSON.fast_generate(data))
+      json = client.post("/v1/sys/mounts/#{encode_path(path)}/tune", JSON.generate(data))
       return true
     end
 
@@ -155,7 +155,7 @@ module Vault
     #
     # @return [true]
     def remount(from, to)
-      client.post("/v1/sys/remount", JSON.fast_generate(
+      client.post("/v1/sys/remount", JSON.generate(
         from: from,
         to:   to,
       ))

--- a/lib/vault/api/sys/policy.rb
+++ b/lib/vault/api/sys/policy.rb
@@ -73,7 +73,7 @@ module Vault
     #
     # @return [true]
     def put_policy(name, rules)
-      client.put("/v1/sys/policy/#{encode_path(name)}", JSON.fast_generate(
+      client.put("/v1/sys/policy/#{encode_path(name)}", JSON.generate(
         rules: rules,
       ))
       return true

--- a/lib/vault/api/sys/quota.rb
+++ b/lib/vault/api/sys/quota.rb
@@ -60,7 +60,7 @@ module Vault
 
     def create_quota(type, name, opts={})
       path = generate_path(type, name)
-      client.post(path, JSON.fast_generate(opts))
+      client.post(path, JSON.generate(opts))
       return true
     end
 
@@ -83,7 +83,7 @@ module Vault
     end
     
     def update_quota_config(opts={})
-      client.post("v1/sys/quotas/config", JSON.fast_generate(opts))
+      client.post("v1/sys/quotas/config", JSON.generate(opts))
       return true
     end
 

--- a/lib/vault/api/sys/seal.rb
+++ b/lib/vault/api/sys/seal.rb
@@ -75,7 +75,7 @@ module Vault
     #
     # @return [SealStatus]
     def unseal(shard)
-      json = client.put("/v1/sys/unseal", JSON.fast_generate(
+      json = client.put("/v1/sys/unseal", JSON.generate(
         key: shard,
       ))
       return SealStatus.decode(json)

--- a/lib/vault/api/transform.rb
+++ b/lib/vault/api/transform.rb
@@ -16,12 +16,12 @@ module Vault
   class Transform < Request
     def encode(role_name:, **opts)
       opts ||= {}
-      client.post("/v1/transform/encode/#{encode_path(role_name)}", JSON.fast_generate(opts))
+      client.post("/v1/transform/encode/#{encode_path(role_name)}", JSON.generate(opts))
     end
 
     def decode(role_name:, **opts)
       opts ||= {}
-      client.post("/v1/transform/decode/#{encode_path(role_name)}", JSON.fast_generate(opts))
+      client.post("/v1/transform/decode/#{encode_path(role_name)}", JSON.generate(opts))
     end
   end
 end

--- a/lib/vault/api/transform/alphabet.rb
+++ b/lib/vault/api/transform/alphabet.rb
@@ -16,7 +16,7 @@ module Vault
     def create_alphabet(name, alphabet:, **opts)
       opts ||= {}
       opts[:alphabet] = alphabet
-      client.post("/v1/transform/alphabet/#{encode_path(name)}", JSON.fast_generate(opts))
+      client.post("/v1/transform/alphabet/#{encode_path(name)}", JSON.generate(opts))
       return true
     end
 

--- a/lib/vault/api/transform/role.rb
+++ b/lib/vault/api/transform/role.rb
@@ -15,7 +15,7 @@ module Vault
 
     def create_role(name, **opts)
       opts ||= {}
-      client.post("/v1/transform/role/#{encode_path(name)}", JSON.fast_generate(opts))
+      client.post("/v1/transform/role/#{encode_path(name)}", JSON.generate(opts))
       return true
     end
 

--- a/lib/vault/api/transform/template.rb
+++ b/lib/vault/api/transform/template.rb
@@ -27,7 +27,7 @@ module Vault
       opts ||= {}
       opts[:type] = type
       opts[:pattern] = pattern
-      client.post("/v1/transform/template/#{encode_path(name)}", JSON.fast_generate(opts))
+      client.post("/v1/transform/template/#{encode_path(name)}", JSON.generate(opts))
       return true
     end
 

--- a/lib/vault/api/transform/transformation.rb
+++ b/lib/vault/api/transform/transformation.rb
@@ -34,7 +34,7 @@ module Vault
       opts ||= {}
       opts[:type] = type
       opts[:template] = template
-      client.post("/v1/transform/transformation/#{encode_path(name)}", JSON.fast_generate(opts))
+      client.post("/v1/transform/transformation/#{encode_path(name)}", JSON.generate(opts))
       return true
     end
 

--- a/spec/integration/api/auth_spec.rb
+++ b/spec/integration/api/auth_spec.rb
@@ -189,7 +189,7 @@ module Vault
     describe "#aws_iam", vault: "> 0.7.3" do
       before(:context) do
         vault_test_client.sys.enable_auth("aws", "aws", nil)
-        vault_test_client.post("/v1/auth/aws/config/client", JSON.fast_generate("iam_server_id_header_value" => "iam_header_canary"))
+        vault_test_client.post("/v1/auth/aws/config/client", JSON.generate("iam_server_id_header_value" => "iam_header_canary"))
       end
 
       after(:context) do
@@ -242,9 +242,9 @@ module Vault
         skip "gcp auth requires real resources and keys"
 
         vault_test_client.sys.enable_auth("gcp", "gcp", nil)
-        vault_test_client.post("/v1/auth/gcp/config", JSON.fast_generate("service_account" => "rspec_service_account"))
-        vault_test_client.post("/v1/auth/gcp/role/rspec_wrong_role", JSON.fast_generate("name" => "rspec_role", "project_id" => "wrong_project_id", "bound_service_accounts" => "\*", "type" => "iam"))
-        vault_test_client.post("/v1/auth/gcp/role/rspec_role", JSON.fast_generate("name" => "rspec_role", "project_id" => "project_id", "bound_service_accounts" => "\*", "type" => "iam"))
+        vault_test_client.post("/v1/auth/gcp/config", JSON.generate("service_account" => "rspec_service_account"))
+        vault_test_client.post("/v1/auth/gcp/role/rspec_wrong_role", JSON.generate("name" => "rspec_role", "project_id" => "wrong_project_id", "bound_service_accounts" => "\*", "type" => "iam"))
+        vault_test_client.post("/v1/auth/gcp/role/rspec_role", JSON.generate("name" => "rspec_role", "project_id" => "project_id", "bound_service_accounts" => "\*", "type" => "iam"))
       end
 
       after(:context) do


### PR DESCRIPTION
`JSON.fast_generate` is deprecated and will be removed in json 3.0.0, just use `JSON.generate`.